### PR TITLE
Update `tinyvec` to 1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ log = "0.4"
 num-traits = "0.2"
 rental = "0.5.5"
 rustc-hash = "1.1.0"
-tinyvec = { version = "0.3.3", features = ["alloc"] }
+tinyvec = { version = "1", features = ["alloc"] }
 unicode-joining-type = "0.3.0"
 
 [dev-dependencies]

--- a/tests/shape.rs
+++ b/tests/shape.rs
@@ -30,7 +30,7 @@ pub fn map_glyph(
 // Copy of `bin/shape::make_glyph`
 pub fn make_glyph(ch: char, glyph_index: u16) -> RawGlyph<()> {
     RawGlyph {
-        unicodes: tiny_vec![[char; 1], ch],
+        unicodes: tiny_vec![[char; 1] => ch],
         glyph_index: Some(glyph_index),
         liga_component_pos: 0,
         glyph_origin: GlyphOrigin::Char(ch),


### PR DESCRIPTION
Hi, `tinyvec` lead here. Just giving you an update.

There's usually no break moving from 0.3 to 1.0, there were some small macro changes though so some people potentially have to update their macro usage.

We'll let CI figure it out!