### PR TITLE
Fix #39

### DIFF
--- a/src/gpos.rs
+++ b/src/gpos.rs
@@ -394,7 +394,8 @@ pub struct Info {
     /// When not `MarkPlacement::None` indicates that this glyph is a mark with placement
     /// indicated by the variant.
     pub mark_placement: MarkPlacement,
-    is_mark: bool,
+    /// Whether this glyph should use `MarkPlacement` or `Placement`
+    pub is_mark: bool,
 }
 
 impl Glyph for Info {

--- a/src/gpos.rs
+++ b/src/gpos.rs
@@ -394,8 +394,7 @@ pub struct Info {
     /// When not `MarkPlacement::None` indicates that this glyph is a mark with placement
     /// indicated by the variant.
     pub mark_placement: MarkPlacement,
-    /// Whether this glyph should use `MarkPlacement` or `Placement`
-    pub is_mark: bool,
+    is_mark: bool,
 }
 
 impl Glyph for Info {

--- a/src/tables.rs
+++ b/src/tables.rs
@@ -57,7 +57,7 @@ pub struct F2Dot14(u16);
 /// The size of the offsets in the `loca` table
 ///
 /// <https://docs.microsoft.com/en-us/typography/opentype/spec/loca>
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum IndexToLocFormat {
     /// Offsets are 16-bit. The actual local offset divided by 2 is stored.
     Short,
@@ -104,7 +104,7 @@ pub struct OffsetTableFontProvider<'a> {
 /// An entry in the Offset Table
 ///
 /// <https://docs.microsoft.com/en-us/typography/opentype/spec/otff#organization-of-an-opentype-font>
-#[derive(Clone)]
+#[derive(Debug, Copy, Clone, PartialEq, PartialOrd, Hash)]
 pub struct TableRecord {
     pub table_tag: u32,
     pub checksum: u32,
@@ -115,7 +115,7 @@ pub struct TableRecord {
 /// `head` table
 ///
 /// <https://docs.microsoft.com/en-us/typography/opentype/spec/head>
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, Copy, Clone, PartialEq, PartialOrd, Hash)]
 pub struct HeadTable {
     pub major_version: u16,
     pub minor_version: u16,
@@ -144,6 +144,7 @@ pub struct HeadTable {
 /// <https://docs.microsoft.com/en-us/typography/opentype/spec/hhea>
 ///
 /// This struct is also used for the `vhea` table.
+#[derive(Debug, Copy, Clone, PartialEq, PartialOrd, Hash)]
 pub struct HheaTable {
     pub ascender: i16,
     pub descender: i16,

--- a/src/tables.rs
+++ b/src/tables.rs
@@ -187,14 +187,14 @@ pub struct LongHorMetric {
 /// must use Version 1.0 of this table, where all data is required.
 ///
 /// <https://docs.microsoft.com/en-us/typography/opentype/spec/maxp>
-#[derive(Debug)]
+#[derive(Debug, Copy, Clone, PartialEq, PartialOrd, Hash)]
 pub struct MaxpTable {
     pub num_glyphs: u16,
     /// Extra fields, present if maxp table is version 1.0, absent if version 0.5.
     pub version1_sub_table: Option<MaxpVersion1SubTable>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Copy, Clone, PartialEq, PartialOrd, Hash)]
 pub struct MaxpVersion1SubTable {
     /// Maximum points in a non-composite glyph.
     pub max_points: u16,

--- a/src/tables/cmap.rs
+++ b/src/tables/cmap.rs
@@ -796,7 +796,7 @@ fn offset_to_index(
 pub mod owned {
     use super::{
         size, Format4Calculator, I16Be, SequentialMapGroup, TryFrom, U16Be, U32Be, WriteBinary,
-        WriteContext, WriteError,
+        WriteContext, WriteError, offset_to_index, ParseError,
     };
 
     pub struct Cmap {
@@ -836,6 +836,103 @@ pub mod owned {
             language: u32,
             groups: Vec<SequentialMapGroup>,
         },
+    }
+
+    impl CmapSubtable {
+        pub fn map_glyph(&self, ch: u32) -> Result<Option<u16>, ParseError> {
+            match *self {
+                CmapSubtable::Format0 {
+                    ref glyph_id_array, ..
+                } => {
+                    let index = usize::try_from(ch)?;
+                    if index < glyph_id_array.len() {
+                        let glyph_id = glyph_id_array[index];
+                        Ok(Some(u16::from(glyph_id)))
+                    } else {
+                        Ok(None)
+                    }
+                }
+                CmapSubtable::Format4 {
+                    ref end_codes,
+                    ref start_codes,
+                    ref id_deltas,
+                    ref id_range_offsets,
+                    ref glyph_id_array,
+                    ..
+                } => {
+                    for i in 0..end_codes.len() {
+                        // Find segment that contains `ch`
+                        let end_code = u32::from(end_codes[i]);
+                        let start_code = u32::from(start_codes[i]);
+                        if start_code <= ch && ch <= end_code {
+                            // This segment contains ch
+                            let id_delta = i32::from(id_deltas[i]);
+                            let id_range_offset = id_range_offsets[i];
+                            let glyph_id = if id_range_offset == 0 {
+                                // If the idRangeOffset is 0, the idDelta value is added directly to
+                                // the character code offset (i.e. idDelta[i] + c) to get the
+                                // corresponding glyph index. The idDelta arithmetic is modulo 65536.
+                                (((ch as i32) + id_delta) as u32) & 0xFFFF
+                            } else {
+                                let index = offset_to_index(
+                                    i,
+                                    id_range_offset,
+                                    ch - start_code,
+                                    id_range_offsets.len(),
+                                )?;
+                                ((i32::from(glyph_id_array[index]) + id_delta) as u32) & 0xFFFF
+                            };
+                            return Ok(Some(glyph_id as u16));
+                        }
+                    }
+                    Ok(None)
+                }
+                CmapSubtable::Format6 {
+                    first_code,
+                    ref glyph_id_array,
+                    ..
+                } => {
+                    let first_code = u32::from(first_code);
+                    if first_code <= ch {
+                        let index = usize::try_from(ch - first_code)?;
+                        if index < glyph_id_array.len() {
+                            let glyph_id = glyph_id_array[index];
+                            Ok(Some(glyph_id))
+                        } else {
+                            Ok(None)
+                        }
+                    } else {
+                        Ok(None)
+                    }
+                }
+                CmapSubtable::Format10 {
+                    start_char_code,
+                    ref glyph_id_array,
+                    ..
+                } => {
+                    if ch >= start_char_code {
+                        let index = usize::try_from(ch - start_char_code)?;
+                        if index < glyph_id_array.len() {
+                            let glyph_id = glyph_id_array[index];
+                            Ok(Some(glyph_id))
+                        } else {
+                            Ok(None)
+                        }
+                    } else {
+                        Ok(None)
+                    }
+                }
+                CmapSubtable::Format12 { ref groups, .. } => {
+                    for group in groups {
+                        if group.start_char_code <= ch && ch <= group.end_char_code {
+                            let glyph_id = group.start_glyph_id + (ch - group.start_char_code);
+                            return Ok(Some(u16::try_from(glyph_id)?));
+                        }
+                    }
+                    Ok(None)
+                }
+            }
+        }
     }
 
     impl<'a> WriteBinary<Self> for Cmap {

--- a/src/tables/cmap.rs
+++ b/src/tables/cmap.rs
@@ -799,16 +799,19 @@ pub mod owned {
         WriteContext, WriteError, offset_to_index, ParseError,
     };
 
+    #[derive(Debug, Clone, PartialEq)]
     pub struct Cmap {
         pub encoding_records: Vec<EncodingRecord>,
     }
 
+    #[derive(Debug, Clone, PartialEq)]
     pub struct EncodingRecord {
         pub platform_id: u16,
         pub encoding_id: u16,
         pub sub_table: CmapSubtable,
     }
 
+    #[derive(Debug, Clone, PartialEq)]
     pub enum CmapSubtable {
         Format0 {
             language: u16,


### PR DESCRIPTION
NOTE: The code for `.map_glyph` is duplicated, which isn't great. I can't create a `ReadArray<T>` from a `Vec<T>`, so I can only either duplicate the code or use a macro. 