### PR TITLE
Run build without default features in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,3 +23,4 @@ jobs:
 script:
   # - cargo fmt -- --check
   - cargo test
+  - cargo check --no-default-features


### PR DESCRIPTION
With the recently introduced `outline` cargo feature, ensure that the code builds with and without the feature enabled in CI.