### PR TITLE
Emit error if Allsorts is built without one of the flate2 features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ bitreader = "0.3.2"
 brotli-decompressor = "2.3"
 byteorder = "1.2"
 encoding_rs = "0.8.16"
-flate2 = { version = "1.0", default-features = false }
+flate2 = { version = "1.0", default-features = false, optional = true }
 glyph-names = "0.1"
 itertools = "0.8"
 lazy_static = "1.3.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -175,3 +175,6 @@ macro_rules! read_table {
             .read::<$t>()
     };
 }
+
+#[cfg(not(any(feature = "flate2_zlib", feature = "flate2_rust")))]
+compile_error!("Allsorts is being built without one of `flate2_zlib` or `flate2_rust` Cargo features enabled. One of these must be enabled");


### PR DESCRIPTION
Fixes #53 

If Allsorts is built without one of the flate2 features enabled emit a compile error with a message indicating this. The `flate2` dependency is also marked optional so that in this case we a avoid a bunch of cryptic errors from trying to build that crate without a backend. There are still errors originating from Allsorts attempting to use `flate2` when it's not been pulled in but there's fewer of them and they're a bit more obviously tied to the `flate2` dependency.