### PR TITLE
Allow the tables to consult for images to be specified

### DIFF
--- a/src/bitmap.rs
+++ b/src/bitmap.rs
@@ -79,6 +79,7 @@ pub enum EncapsulatedFormat {
 }
 
 /// Bitmap glyph metrics either embedded or from `hmtx`/`vmtx`.
+#[derive(Debug)]
 pub enum Metrics {
     /// Metrics were embedded with the bitmap.
     Embedded(EmbeddedMetrics),
@@ -111,7 +112,7 @@ pub struct EmbeddedMetrics {
 }
 
 /// The actual embedded bitmap glyph metrics in pixels.
-#[derive(Debug)]
+#[derive(Copy, Clone, Debug)]
 pub struct BitmapMetrics {
     /// Distance in pixels from the horizontal origin to the left edge of the bitmap.
     pub origin_offset_x: i16,


### PR DESCRIPTION
For changes I'm making in https://github.com/wezm/profont/pull/14 I need to be able to access B&W images in the `EBDT` table. This PR adds a mask that sets the tables to consult for images. It defaults to what we previously supported but there is a new method that allows it to be overridden. This allows me to opt-into reading from the `EBDT` table in my PR above but should not change any existing behaviour.