### PR TITLE
fix: OS/2 tables must be included when subsetting OpenType fonts

### DIFF
--- a/src/subset.rs
+++ b/src/subset.rs
@@ -130,6 +130,7 @@ fn subset_ttf(
     let fpgm = provider.table_data(tag::FPGM)?;
     let name = provider.table_data(tag::NAME)?;
     let prep = provider.table_data(tag::PREP)?;
+    let os_2 = provider.read_table_data(tag::OS_2)?;
 
     // Build the new font
     let mut builder = FontBuilder::new(0x00010000_u32);
@@ -146,6 +147,7 @@ fn subset_ttf(
     if let Some(name) = name {
         builder.add_table::<_, ReadScope<'_>>(tag::NAME, ReadScope::new(&name), ())?;
     }
+    builder.add_table::<_, ReadScope<'_>>(tag::OS_2, ReadScope::new(&os_2), ())?;
     builder.add_table::<_, PostTable<'_>>(tag::POST, &post, ())?;
     if let Some(prep) = prep {
         builder.add_table::<_, ReadScope<'_>>(tag::PREP, ReadScope::new(&prep), ())?;


### PR DESCRIPTION
In Chrome and Firefox, use [OpenType Sanitizer](https://github.com/khaledhosny/ots) to check the validity of fonts. Can we introduce OpenType Sanitizer to test the validity of allsorts subsetted fonts?

```bash
 ttx -l SourceSerifPro-Regular-sub.ttf
Listing table info for "SourceSerifPro-Regular-sub.ttf":
    tag     checksum    length    offset
    ----  ----------  --------  --------
    OS/2  0x60539B1C        96       188
    cmap  0x0703061B       274       284
    glyf  0x5CD24954       710       560
    head  0x1BB196DC        54      1272
    hhea  0x0B6406B6        36      1328
    hmtx  0x0DBE0104        28      1364
    loca  0x01F702D0        16      1392
    maxp  0x001700ED        32      1408
    name  0x25D3FFE5      1978      1440
    post  0xFFD10032        32      3420
    prep  0x68068C85         7      3452
```

Fixes: https://github.com/yeslogic/allsorts-tools/issues/16