### PR TITLE
Update regex; limit flate2/libz-sys to versions compatible with older versions of Rust

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "allsorts"
-version = "0.9.0"
+version = "0.9.1"
 authors = ["YesLogic Pty. Ltd. <info@yeslogic.com>"]
 edition = "2018"
 
@@ -41,7 +41,7 @@ unicode-joining-type = "0.6.0"
 pathfinder_geometry = { version = "0.5.1", optional = true }
 
 [dev-dependencies]
-regex = "1.1.6"
+regex = "1.5.6"
 
 # criterion = "0.3"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,9 @@ bitreader = "0.3.2"
 brotli-decompressor = "2.3"
 byteorder = "1.2"
 encoding_rs = "0.8.16"
-flate2 = { version = "1.0", default-features = false, optional = true }
+flate2 = { version = "1.0, < 1.0.24", default-features = false, optional = true }
+# https://github.com/rust-lang/libz-sys/issues/101
+libz-sys = { version = "1.1, < 1.1.7", optional = true }
 glyph-names = "0.1"
 itertools = "0.8"
 lazy_static = "1.3.0"

--- a/src/woff2/collection.rs
+++ b/src/woff2/collection.rs
@@ -4,12 +4,14 @@ use crate::woff2::{PackedU16, TableDirectoryEntry, Woff2Font};
 
 #[derive(Debug)]
 pub struct Directory {
+    #[allow(unused)]
     version: u32,
     entries: Vec<FontEntry>,
 }
 
 #[derive(Debug)]
 pub struct FontEntry {
+    #[allow(unused)]
     flavor: u32,
     table_indices: Vec<usize>,
 }


### PR DESCRIPTION
Feel free to ignore the `pub` changes. Just thought I'd silence them while I was here.