### PR TITLE
Cache less in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: rust
 sudo: false
-cache: cargo
+cache:
+  directories:
+    - $HOME/.cargo
 
 os:
   - linux


### PR DESCRIPTION
The [default `cache: cargo` setting](https://docs.travis-ci.com/user/caching/#rust-cargo-cache) caches `$HOME/.cargo` and `$TRAVIS_BUILD_DIR/target`. This is producing a 38Gb cache archive, which is slow to download and extract (~3 mins) and slow to compress and upload. I think ultimately it's slowing builds down. A build is currently taking about 20 mins. This change removes the `target` directory from the cache to see how that affects things.

**Edit** actually the 38Gb might be the sum of all platform and version caches for a given branch. Nonetheless the 3 mins is accurate.