### PR TITLE
Use `u32::from_be_bytes` in `tag!` macro

### DIFF
--- a/src/tag.rs
+++ b/src/tag.rs
@@ -16,7 +16,7 @@ use std::{fmt, str};
 #[macro_export]
 macro_rules! tag {
     ($w:expr) => {
-        $crate::tag::tag_from_bytes(*$w)
+        u32::from_be_bytes(*$w)
     };
 }
 
@@ -36,14 +36,6 @@ macro_rules! tag {
 /// ```
 #[derive(PartialEq, Eq, Clone, Copy)]
 pub struct DisplayTag(pub u32);
-
-#[doc(hidden)]
-pub const fn tag_from_bytes(chars: [u8; 4]) -> u32 {
-    ((chars[3] as u32) << 0)
-        | ((chars[2] as u32) << 8)
-        | ((chars[1] as u32) << 16)
-        | ((chars[0] as u32) << 24)
-}
 
 pub fn from_string(s: &str) -> Result<u32, ParseError> {
     if s.len() > 4 {


### PR DESCRIPTION
OK, so I saw this while working on #69 and couldn't ignore it. You're doing manual bit shifting when you could be using `u32::from_be_bytes`. I'm not aware of any reason for this, so I swapped it out and it works just fine.

`from_be_bytes` has been const-stable since Rust 1.44.0. (Admittedly this is newer than allsorts itself.)