### PR TITLE
Changes for better caching and sharing parsed fonts

### DIFF
--- a/src/font_data.rs
+++ b/src/font_data.rs
@@ -59,7 +59,7 @@ impl<'a> SfntVersion for DynamicFontTableProvider<'a> {
 impl<'a> FontData<'a> {
     /// Obtain an implementation of `FontTableProvider` for this font.
     pub fn table_provider(
-        &'a self,
+        self,
         index: usize,
     ) -> Result<DynamicFontTableProvider<'a>, ReadWriteError> {
         match self {

--- a/src/glyph_position.rs
+++ b/src/glyph_position.rs
@@ -14,16 +14,12 @@ use std::convert::TryFrom;
 use crate::context::Glyph;
 use crate::error::ParseError;
 use crate::gpos::{Info, Placement};
-use crate::tables::FontTableProvider;
 use crate::unicode::codepoint::is_upright_char;
 use crate::Font;
 
 /// Used to calculate the position of shaped glyphs.
-pub struct GlyphLayout<'f, 'i, T>
-where
-    T: FontTableProvider,
-{
-    font: &'f mut Font<T>,
+pub struct GlyphLayout<'f, 'i, 's> {
+    font: &'f mut Font<'s>,
     infos: &'i [Info],
     direction: TextDirection,
     vertical: bool,
@@ -50,7 +46,7 @@ pub enum TextDirection {
     RightToLeft,
 }
 
-impl<'f, 'i, T: FontTableProvider> GlyphLayout<'f, 'i, T> {
+impl<'f, 'i, 's> GlyphLayout<'f, 'i, 's> {
     /// Construct a new `GlyphLayout` instance.
     ///
     /// **Arguments**
@@ -60,7 +56,7 @@ impl<'f, 'i, T: FontTableProvider> GlyphLayout<'f, 'i, T> {
     /// * `direction` — the horizontal text layout direction.
     /// * `vertical` — `true` if the text is being laid out top to bottom.
     pub fn new(
-        font: &'f mut Font<T>,
+        font: &'f mut Font<'s>,
         infos: &'i [Info],
         direction: TextDirection,
         vertical: bool,
@@ -325,8 +321,8 @@ fn sum_advance(positions: Option<&[GlyphPosition]>) -> (i32, i32) {
     })
 }
 
-fn glyph_advance<T: FontTableProvider>(
-    font: &mut Font<T>,
+fn glyph_advance<'f>(
+    font: &mut Font<'f>,
     info: &Info,
     vertical: bool,
 ) -> Result<(i32, i32), ParseError> {

--- a/src/tables.rs
+++ b/src/tables.rs
@@ -38,7 +38,11 @@ pub struct Fixed(i32);
 /// The value is represented as a signed 64-bit integer.
 type LongDateTime = i64;
 
-pub trait FontTableProvider {
+pub trait SfntVersion {
+    fn sfnt_version(&self) -> u32;
+}
+
+pub trait FontTableProvider: SfntVersion {
     /// Return data for the specified table if present
     fn table_data<'a>(&'a self, tag: u32) -> Result<Option<Cow<'a, [u8]>>, ParseError>;
 
@@ -49,8 +53,13 @@ pub trait FontTableProvider {
     }
 }
 
-pub trait SfntVersion {
-    fn sfnt_version(&self) -> u32;
+impl<'a, T> From<T> for Box<dyn FontTableProvider + 'a>
+where
+    T: FontTableProvider + 'a,
+{
+    fn from(provider: T) -> Self {
+        Box::new(provider)
+    }
 }
 
 /// The F2DOT14 format consists of a signed, 2’s complement integer and an unsigned fraction.

--- a/tests/indic.rs
+++ b/tests/indic.rs
@@ -17,12 +17,12 @@ use allsorts::error::ShapingError;
 use allsorts::gsub::{self, FeatureMask, Features, RawGlyph};
 use allsorts::scripts::preprocess_text;
 use allsorts::tables::cmap::CmapSubtable;
-use allsorts::tables::{FontTableProvider, OpenTypeFont};
+use allsorts::tables::OpenTypeFont;
 use allsorts::{tag, Font, DOTTED_CIRCLE};
 
 // Variant of `bin/shape::shape_ttf`
-fn shape_ttf_indic<'a, T: FontTableProvider>(
-    font: &mut Font<T>,
+fn shape_ttf_indic(
+    font: &mut Font<'_>,
     script_tag: u32,
     opt_lang_tag: Option<u32>,
     text: &str,

--- a/tests/khmer.rs
+++ b/tests/khmer.rs
@@ -17,12 +17,12 @@ use allsorts::error::ShapingError;
 use allsorts::gsub::{self, FeatureMask, Features};
 use allsorts::scripts::preprocess_text;
 use allsorts::tables::cmap::CmapSubtable;
-use allsorts::tables::{FontTableProvider, OpenTypeFont};
+use allsorts::tables::OpenTypeFont;
 use allsorts::{tag, Font, DOTTED_CIRCLE};
 
 // Variant of `bin/shape::shape_ttf`
-fn shape_ttf_khmer<'a, T: FontTableProvider>(
-    font: &mut Font<T>,
+fn shape_ttf_khmer(
+    font: &mut Font<'_>,
     script_tag: u32,
     lang_tag: Option<u32>,
     text: &str,

--- a/tests/opentype.rs
+++ b/tests/opentype.rs
@@ -17,9 +17,7 @@ use allsorts::tables::glyf::{
     BoundingBox, GlyfRecord, GlyfTable, Glyph, GlyphData, Point, SimpleGlyph, SimpleGlyphFlag,
 };
 use allsorts::tables::loca::LocaTable;
-use allsorts::tables::{
-    Fixed, FontTableProvider, HeadTable, IndexToLocFormat, MaxpTable, OpenTypeData, OpenTypeFont,
-};
+use allsorts::tables::{Fixed, HeadTable, IndexToLocFormat, MaxpTable, OpenTypeData, OpenTypeFont};
 use allsorts::{tag, Font, DOTTED_CIRCLE};
 
 use crate::common::read_fixture;
@@ -207,8 +205,8 @@ fn test_decode_cmap_format_2() {
     // aots::cmap2_test1
 }
 
-fn shape<'a, T: FontTableProvider>(
-    font: &mut Font<T>,
+fn shape(
+    font: &mut Font,
     script_tag: u32,
     opt_lang_tag: Option<u32>,
     text: &str,


### PR DESCRIPTION
In principle I made two changes:
* I replaced generic T in (`Font<T: FontTableProvider>`) with `&dyn FontTableProvider`, what allows caching Font instances of different types (OTF, WOFF...).
* I made FontData self consuming in , what allows better separating `ReadScope` font source from Font itself. Font then can be cached only with keeping single self-referenced data (`ReadScope`).

I removed generic `T` from `Font` without breaking API compatibility, with the help of `impl Into<Box<dyn FontTableProvider + 'a>>`, which is rather complex. Definitely this could be arranged better if API was changed (what I did not want).

It should also help with #52 and with some discussed points in #72.