### PR TITLE
Add a function to list tags to the `FontTableProvider` trait.

### DIFF
--- a/src/font_data.rs
+++ b/src/font_data.rs
@@ -41,6 +41,10 @@ impl<'b> ReadBinary for FontData<'b> {
 }
 
 impl<'a> FontTableProvider for DynamicFontTableProvider<'a> {
+    fn table_tags(&self) -> Vec<u32> {
+        self.provider.table_tags()
+    }
+
     fn table_data(&self, tag: u32) -> Result<Option<Cow<'_, [u8]>>, ParseError> {
         self.provider.table_data(tag)
     }

--- a/src/woff.rs
+++ b/src/woff.rs
@@ -93,6 +93,13 @@ impl<'b> ReadBinary for WoffFont<'b> {
 }
 
 impl<'a> FontTableProvider for WoffFont<'a> {
+    fn table_tags(&self) -> Vec<u32> {
+        self.table_directory
+            .iter()
+            .map(|table_entry| table_entry.tag)
+            .collect()
+    }
+
     fn table_data(&self, tag: u32) -> Result<Option<Cow<'_, [u8]>>, ParseError> {
         self.find_table_directory_entry(tag)
             .map(|table_entry| {

--- a/src/woff2.rs
+++ b/src/woff2.rs
@@ -234,6 +234,10 @@ impl<'b> ReadBinary for Woff2Font<'b> {
 }
 
 impl FontTableProvider for Woff2TableProvider {
+    fn table_tags(&self) -> Vec<u32> {
+        self.tables.keys().copied().collect()
+    }
+
     fn table_data(&self, tag: u32) -> Result<Option<Cow<'_, [u8]>>, ParseError> {
         Ok(self.tables.get(&tag).map(|table| Cow::from(table.as_ref())))
     }


### PR DESCRIPTION
Until now, the `FontTableProvider` only allowed to find the table for a specific tag. This adds a function to list all the tags present in the font.

The proposed API is `fn table_tags(&self) -> Vec<u32>`.
- It could also be `fn table_tags(&self) -> impl Iterator<Item = u32>`, but that would require [return-position `impl Trait` in trait](https://github.com/rust-lang/rust/pull/115822) (RPITIT) syntax that will stabilize in Rust 1.75 next week. Using RPITIT would also prevent the `FontTableProvider` trait from being "object safe", which would mean that the `DynamicFontTableProvider` would not be able to use a `dyn FontTableProvider` (it could use an enum over all possible providers though).

It could also be useful to have a function directly returning a collection of `(tag, table)` (or an `impl Iterator`), so that one wouldn't need to find the table for each tag after listing the tags. Currently `Woff2TableProvider` provides the `into_tables(self) -> HashMap<u32, Box<[u8]>>` function, but it's not clear to me whether a `HashMap` is the best type for all font providers.