### PR TITLE
Add subsetting profiles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 **/*.rs.bk
 .idea
 /Cargo.lock
+.DS_Store

--- a/src/font.rs
+++ b/src/font.rs
@@ -29,7 +29,7 @@ use crate::tables::variable_fonts::fvar::{FvarAxisCount, FvarTable, Tuple, Varia
 use crate::tables::{kern, FontTableProvider, HeadTable, HheaTable, MaxpTable};
 use crate::unicode::{self, VariationSelector};
 use crate::variations::{AxisNamesError, NamedAxis};
-use crate::{glyph_info, tag, variations};
+use crate::{glyph_info, tag, variations, SafeFrom};
 use crate::{gpos, gsub, DOTTED_CIRCLE};
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
@@ -206,7 +206,7 @@ impl<T: FontTableProvider> Font<T> {
                     hhea_table,
                     vmtx_table: LazyLoad::NotLoaded,
                     vhea_table: LazyLoad::NotLoaded,
-                    cmap_subtable_offset: usize::try_from(cmap_subtable_offset)?,
+                    cmap_subtable_offset: usize::safe_from(cmap_subtable_offset),
                     cmap_subtable_encoding,
                     gdef_cache: LazyLoad::NotLoaded,
                     morx_cache: LazyLoad::NotLoaded,

--- a/src/subset.rs
+++ b/src/subset.rs
@@ -83,38 +83,49 @@ const PROFILE_FULL: &[u32] = &[
 ];
 
 impl SubsetProfile {
-    /// Parses a custom subset profile from a string such as "gsub,vmtx,prep", includes the minimal tables automatically
-    pub fn parse_custom(s: &str) -> Self {
-        let mut tables = PROFILE_MINIMAL.to_vec();
-        let s = s
-            .split(",")
-            .flat_map(|s| s.split_whitespace().into_iter())
-            .collect::<BTreeSet<_>>();
-        for feature in s.iter() {
-            let newtag = match feature.to_lowercase().as_str() {
-                "cmap" => tag::CMAP,
-                "head" => tag::HEAD,
-                "hhea" => tag::HHEA,
-                "htmx" => tag::HMTX,
-                "maxp" => tag::MAXP,
-                "name" => tag::NAME,
-                "os/2" | "os2" | "os_2" => tag::OS_2,
-                "post" => tag::POST,
-                "gpos" => tag::GPOS,
-                "gsub" => tag::GSUB,
-                "vhea" => tag::VHEA,
-                "vtmx" => tag::VMTX,
-                "gdef" => tag::GDEF,
-                "cvt" => tag::CVT,
-                "fpgm" => tag::FPGM,
-                "prep" => tag::PREP,
-                _ => continue,
-            };
-            tables.push(newtag);
-        }
+    /// Parses a custom subset profile from a string
+    ///
+    /// The table names may be separated by commas or whitespace, such as `gsub,vmtx,prep`.
+    /// Case is ignored.
+    /// Tables from the Minimal profile are included automatically.
+    pub fn parse_custom(s: String) -> Result<Self, ParseError> {
+        let mut bytes = s.into_bytes();
+        let tags = bytes
+            .split_mut(|&c| c == b',' || c.is_ascii_whitespace())
+            .map(|name| {
+                name.make_ascii_lowercase();
+                match &*name {
+                    b"cmap" => Ok(tag::CMAP),
+                    b"head" => Ok(tag::HEAD),
+                    b"hhea" => Ok(tag::HHEA),
+                    b"htmx" => Ok(tag::HMTX),
+                    b"maxp" => Ok(tag::MAXP),
+                    b"name" => Ok(tag::NAME),
+                    b"os/2" | b"os2" | b"os_2" => Ok(tag::OS_2),
+                    b"post" => Ok(tag::POST),
+                    b"gpos" => Ok(tag::GPOS),
+                    b"gsub" => Ok(tag::GSUB),
+                    b"vhea" => Ok(tag::VHEA),
+                    b"vtmx" => Ok(tag::VMTX),
+                    b"gdef" => Ok(tag::GDEF),
+                    b"cvt" => Ok(tag::CVT),
+                    b"fpgm" => Ok(tag::FPGM),
+                    b"prep" => Ok(tag::PREP),
+                    other => {
+                        let tag_str = str::from_utf8(other).map_err(|_| ParseError::BadValue)?;
+                        tag::from_string(tag_str)
+                    }
+                }
+            });
+        let mut tables = PROFILE_MINIMAL
+            .iter()
+            .copied()
+            .map(Ok)
+            .chain(tags)
+            .collect::<Result<Vec<_>, _>>()?;
         tables.sort();
         tables.dedup();
-        Self::Custom(tables)
+        Ok(Self::Custom(tables))
     }
 
     /// Returns the tables needed to subset for this profile.
@@ -1614,5 +1625,25 @@ mod tests {
         assert_eq!(cff.fonts.len(), 1);
         let font = &cff.fonts[0];
         assert!(font.is_cid_keyed());
+    }
+
+    #[test]
+    fn parse_custom_profile() {
+        let tables = "abcd,OS/2 os2,GSUB".to_string();
+        let custom = SubsetProfile::parse_custom(tables).unwrap();
+        let expected = SubsetProfile::Custom(vec![
+            // abcd comes last because uppercase sorts before lowercase
+            tag::GSUB,
+            tag::OS_2,
+            tag!(b"abcd"),
+        ]);
+
+        assert_eq!(custom, expected)
+    }
+
+    #[test]
+    fn parse_custom_profile_invalid() {
+        assert!(SubsetProfile::parse_custom("toolong".to_string()).is_err());
+        assert!(SubsetProfile::parse_custom("👓".to_string()).is_err());
     }
 }

--- a/src/subset.rs
+++ b/src/subset.rs
@@ -54,26 +54,6 @@ const PROFILE_MINIMAL: &[u32] = &[
     tag::POST,
 ];
 
-/// Full set of tables for a valid OpenType subset font (includes layout tables).
-const PROFILE_FULL: &[u32] = &[
-    tag::CMAP,
-    tag::HEAD,
-    tag::HHEA,
-    tag::HMTX,
-    tag::MAXP,
-    tag::NAME,
-    tag::OS_2,
-    tag::POST,
-    tag::GPOS, // Glyph Positioning
-    tag::GSUB, // Glyph Substitution
-    tag::VHEA, // Vertical Header
-    tag::VMTX, // Vertical Metrics
-    tag::GDEF, // Glyph Definition
-    tag::CVT,  // Control Value Table
-    tag::FPGM, // Font Program
-    tag::PREP, // Control Value Program
-];
-
 /// Profiles for controlling the tables included in subset fonts.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum SubsetProfile {
@@ -81,8 +61,6 @@ pub enum SubsetProfile {
     Pdf,
     /// Minimum tables required for a valid OpenType font.
     Minimal,
-    /// Full profile, includes all relevant tables for a fully functional subset font.
-    Full,
 }
 
 /// Target cmap format to use when subsetting
@@ -108,7 +86,6 @@ impl SubsetProfile {
         let tables = match self {
             SubsetProfile::Pdf => PROFILE_PDF,
             SubsetProfile::Minimal => PROFILE_MINIMAL,
-            SubsetProfile::Full => PROFILE_FULL,
         };
         let mut tables = tables.to_vec();
         tables.extend_from_slice(extra);

--- a/src/subset.rs
+++ b/src/subset.rs
@@ -2,7 +2,7 @@
 
 //! Font subsetting.
 
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::BTreeMap;
 use std::convert::TryFrom;
 use std::fmt;
 use std::num::Wrapping;
@@ -129,12 +129,12 @@ impl SubsetProfile {
     }
 
     /// Returns the tables needed to subset for this profile.
-    fn get_tables(&self) -> BTreeSet<u32> {
+    fn get_tables(&self) -> &[u32] {
         match self {
-            SubsetProfile::Minimal => PROFILE_MINIMAL.iter().copied().collect(),
-            SubsetProfile::Web => PROFILE_WEB.iter().copied().collect(),
-            SubsetProfile::Full => PROFILE_FULL.iter().copied().collect(),
-            SubsetProfile::Custom(items) => items.iter().copied().collect(),
+            SubsetProfile::Minimal => PROFILE_MINIMAL,
+            SubsetProfile::Web => PROFILE_WEB,
+            SubsetProfile::Full => PROFILE_FULL,
+            SubsetProfile::Custom(items) => items,
         }
     }
 }

--- a/src/subset.rs
+++ b/src/subset.rs
@@ -1626,7 +1626,9 @@ mod tests {
 
         // Get the cmap subtable for unicode mapping
         let cmap_data = font.cmap_subtable_data();
-        let cmap_subtable = ReadScope::new(cmap_data).read::<CmapSubtable<'_>>().unwrap();
+        let cmap_subtable = ReadScope::new(cmap_data)
+            .read::<CmapSubtable<'_>>()
+            .unwrap();
 
         // Map characters to glyph IDs
         let mut glyph_ids = vec![0]; // Always include glyph 0 (.notdef)
@@ -1649,6 +1651,7 @@ mod tests {
             CmapTarget::Unicode,
         )
         .unwrap();
+        drop(font); // so we don't accidentally use it below
 
         // Validate that the OS/2 table is present in the subsetted font
         let subset_otf = ReadScope::new(&subset_buffer)
@@ -1663,12 +1666,70 @@ mod tests {
         );
 
         // Read back the cmap and check that it's a unicode cmap
-        let cmap_data = font.font_table_provider.read_table_data(tag::CMAP).unwrap();
+        let cmap_data = subset_provider.read_table_data(tag::CMAP).unwrap();
         let cmap = ReadScope::new(&cmap_data).read::<Cmap<'_>>().unwrap();
         assert!(
             cmap.find_subtable(PlatformId::UNICODE, EncodingId::UNICODE_BMP)
                 .is_some(),
             "subset font does not have expected Unicode cmap"
+        );
+    }
+
+    #[test]
+    fn test_subset_with_macroman_cmap() {
+        // Test string to use for the font subset
+        let test_string = "hello world";
+
+        // Load the font
+        let buffer = read_fixture("tests/fonts/opentype/Klei.otf");
+        let opentype_file = ReadScope::new(&buffer).read::<OpenTypeFont<'_>>().unwrap();
+        let provider = opentype_file.table_provider(0).unwrap();
+
+        // Create a font instance to access cmap
+        let font = Font::new(provider).unwrap();
+
+        // Get the cmap subtable for unicode mapping
+        let cmap_data = font.cmap_subtable_data();
+        let cmap_subtable = ReadScope::new(cmap_data)
+            .read::<CmapSubtable<'_>>()
+            .unwrap();
+
+        // Map characters to glyph IDs
+        let mut glyph_ids = vec![0]; // Always include glyph 0 (.notdef)
+
+        for c in test_string.chars() {
+            if let Ok(Some(glyph_id)) = cmap_subtable.map_glyph(c as u32) {
+                glyph_ids.push(glyph_id);
+            }
+        }
+
+        // Sort and deduplicate glyph IDs
+        glyph_ids.sort();
+        glyph_ids.dedup();
+
+        // Subset the font
+        let subset_buffer = subset(
+            &font.font_table_provider,
+            &glyph_ids,
+            &SubsetProfile::Minimal,
+            CmapTarget::Unrestricted,
+        )
+        .unwrap();
+        drop(font); // so we don't accidentally use it below
+
+        let subset_otf = ReadScope::new(&subset_buffer)
+            .read::<OpenTypeFont<'_>>()
+            .unwrap();
+        let subset_provider = subset_otf.table_provider(0).unwrap();
+
+        // Read back the cmap and check that it's a Mac Roman cmap (because all the selected
+        // glyphs are in the Mac Roman character set)
+        let cmap_data = subset_provider.read_table_data(tag::CMAP).unwrap();
+        let cmap = ReadScope::new(&cmap_data).read::<Cmap<'_>>().unwrap();
+        assert!(
+            cmap.find_subtable(PlatformId::MACINTOSH, EncodingId::MACINTOSH_APPLE_ROMAN)
+                .is_some(),
+            "subset font does not have expected Mac Roman cmap"
         );
     }
 }

--- a/src/subset.rs
+++ b/src/subset.rs
@@ -27,6 +27,60 @@ use crate::tables::{
 };
 use crate::{checksum, tag};
 
+/// Profiles for controlling the tables included in subset fonts.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum SubsetProfile {
+    /// Minimal profile, suitable for PDF embedding (smallest file size).
+    Minimal,
+    /// OpenType profile, includes minimum tables for a valid standalone OpenType font.
+    OpenType,
+    /// Full profile, includes all relevant tables for a fully functional subset font.
+    Full,
+    /// Custom profile, allows specifying a list of tables to include.
+    Custom(&'static [u32]),
+}
+
+impl Default for SubsetProfile {
+    fn default() -> Self {
+        SubsetProfile::Minimal
+    }
+}
+
+/// Minimal set of tables for PDF embedding (current behaviour).
+pub const PROFILE_MINIMAL: &[u32] = &[]; // Define minimal table set if any
+
+/// Minimum tables required for a valid standalone OpenType font.
+pub const PROFILE_OPENTYPE: &[u32] = &[
+    tag::CMAP,
+    tag::HEAD,
+    tag::HHEA,
+    tag::HMTX,
+    tag::MAXP,
+    tag::NAME,
+    tag::OS_2,
+    tag::POST,
+];
+
+/// Full set of tables for a fully functional OpenType subset font (includes layout tables).
+pub const PROFILE_FULL: &[u32] = &[
+    tag::CMAP,
+    tag::HEAD,
+    tag::HHEA,
+    tag::HMTX,
+    tag::MAXP,
+    tag::NAME,
+    tag::OS_2,
+    tag::POST,
+    tag::GPOS, // Glyph Positioning
+    tag::GSUB, // Glyph Substitution
+    tag::VHEA, // Vertical Header
+    tag::VMTX, // Vertical Metrics
+    tag::GDEF, // Glyph Definition
+    tag::CVT,  // Control Value Table
+    tag::FPGM, // Font Program
+    tag::PREP, // Control Value Program
+];
+
 /// Error type returned from subsetting.
 #[derive(Debug)]
 pub enum SubsetError {
@@ -89,22 +143,35 @@ struct OrderedTables {
 pub fn subset(
     provider: &impl FontTableProvider,
     glyph_ids: &[u16],
+    profile: SubsetProfile,
 ) -> Result<Vec<u8>, SubsetError> {
-    let mappings_to_keep = MappingsToKeep::new(provider, glyph_ids, CmapTarget::Unrestricted)?;
+    let mappings_to_keep = MappingsToKeep::new(
+        provider, 
+        glyph_ids, 
+        CmapTarget::Unrestricted
+    )?;
     if provider.has_table(tag::CFF) {
-        subset_cff(provider, glyph_ids, mappings_to_keep, true)
+        subset_cff(
+            provider, 
+            glyph_ids, 
+            mappings_to_keep, 
+            profile,
+            true
+        )
     } else if provider.has_table(tag::CFF2) {
         subset_cff2(
             provider,
             glyph_ids,
             mappings_to_keep,
             false,
+            profile,
             OutputFormat::Type1OrCid,
         )
     } else {
         subset_ttf(
             provider,
             glyph_ids,
+            profile,
             CmapStrategy::Generate(mappings_to_keep),
         )
         .map_err(SubsetError::from)
@@ -118,6 +185,7 @@ pub fn subset(
 fn subset_ttf(
     provider: &impl FontTableProvider,
     glyph_ids: &[u16],
+    profile: SubsetProfile,
     cmap_strategy: CmapStrategy,
 ) -> Result<Vec<u8>, ReadWriteError> {
     let head = ReadScope::new(&provider.read_table_data(tag::HEAD)?).read::<HeadTable>()?;
@@ -206,6 +274,7 @@ fn subset_cff(
     provider: &impl FontTableProvider,
     glyph_ids: &[u16],
     mappings_to_keep: MappingsToKeep<OldIds>,
+    profile: SubsetProfile,
     convert_cff_to_cid_if_more_than_255_glyphs: bool,
 ) -> Result<Vec<u8>, SubsetError> {
     let cff_data = provider.read_table_data(tag::CFF)?;
@@ -242,6 +311,7 @@ fn subset_cff2(
     glyph_ids: &[u16],
     mappings_to_keep: MappingsToKeep<OldIds>,
     include_fstype: bool,
+    profile: SubsetProfile,
     output_format: OutputFormat,
 ) -> Result<Vec<u8>, SubsetError> {
     let cff2_data = provider.read_table_data(tag::CFF2)?;
@@ -1255,7 +1325,11 @@ mod tests {
         let opentype_file = ReadScope::new(&buffer).read::<OpenTypeFont<'_>>().unwrap();
         let mut glyph_ids = [0, 9999];
 
-        match subset(&opentype_file.table_provider(0).unwrap(), &mut glyph_ids) {
+        match subset(
+            &opentype_file.table_provider(0).unwrap(), 
+            &mut glyph_ids, 
+            SubsetProfile::Minimal
+        ) {
             Err(SubsetError::Parse(ParseError::BadIndex)) => {}
             err => panic!(
                 "expected SubsetError::Parse(ParseError::BadIndex) got {:?}",
@@ -1272,7 +1346,11 @@ mod tests {
         // glyph 118 is not Unicode, so does not end up in the mappings to keep
         let mut glyph_ids = [0, 118];
         let subset_font_data =
-            subset(&opentype_file.table_provider(0).unwrap(), &mut glyph_ids).unwrap();
+            subset(
+                &opentype_file.table_provider(0).unwrap(), 
+                &mut glyph_ids, 
+                SubsetProfile::Minimal
+            ).unwrap();
 
         let opentype_file = ReadScope::new(&subset_font_data)
             .read::<OpenTypeFont<'_>>()
@@ -1301,6 +1379,7 @@ mod tests {
         let subset_font_data = subset_ttf(
             &opentype_file.table_provider(0).unwrap(),
             &mut glyph_ids,
+            SubsetProfile::Minimal,
             CmapStrategy::Omit,
         )
         .unwrap();
@@ -1360,7 +1439,7 @@ mod tests {
 
         // Subset the CFF2, producing CFF. Since there is only two glyphs in the subset font it
         // will produce a Type 1 CFF font.
-        let new_font = subset(&provider, &[0, 1]).unwrap();
+        let new_font = subset(&provider, &[0, 1], SubsetProfile::Minimal).unwrap();
 
         // Read it back
         let subset_otf = ReadScope::new(&new_font)
@@ -1388,7 +1467,7 @@ mod tests {
         // Subset the CFF2, producing CFF. Since there is more than 255 glyphs in the subset font it
         // will produce a CID-keyed CFF font.
         let glyph_ids = (0..=256).collect::<Vec<_>>();
-        let new_font = subset(&provider, &glyph_ids).unwrap();
+        let new_font = subset(&provider, &glyph_ids, SubsetProfile::Minimal).unwrap();
 
         // Read it back
         let subset_otf = ReadScope::new(&new_font)

--- a/src/subset.rs
+++ b/src/subset.rs
@@ -2,7 +2,7 @@
 
 //! Font subsetting.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::convert::TryFrom;
 use std::fmt;
 use std::num::Wrapping;
@@ -21,6 +21,7 @@ use crate::tables::cmap::subset::{CmapStrategy, CmapTarget, MappingsToKeep, NewI
 use crate::tables::cmap::{owned, EncodingId, PlatformId};
 use crate::tables::glyf::GlyfTable;
 use crate::tables::loca::{self, LocaTable};
+use crate::tables::os2::Os2;
 use crate::tables::{
     self, cmap, FontTableProvider, HeadTable, HheaTable, HmtxTable, IndexToLocFormat, MaxpTable,
     TableRecord,
@@ -28,7 +29,7 @@ use crate::tables::{
 use crate::{checksum, tag};
 
 /// Profiles for controlling the tables included in subset fonts.
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum SubsetProfile {
     /// Minimal profile, suitable for PDF embedding (smallest file size).
     Minimal,
@@ -37,7 +38,7 @@ pub enum SubsetProfile {
     /// Full profile, includes all relevant tables for a fully functional subset font.
     Full,
     /// Custom profile, allows specifying a list of tables to include.
-    Custom(&'static [u32]),
+    Custom(Vec<u32>),
 }
 
 impl Default for SubsetProfile {
@@ -47,10 +48,10 @@ impl Default for SubsetProfile {
 }
 
 /// Minimal set of tables for PDF embedding (current behaviour).
-pub const PROFILE_MINIMAL: &[u32] = &[]; // Define minimal table set if any
+const PROFILE_MINIMAL: &[u32] = &[]; // Define minimal table set if any
 
 /// Minimum tables required for a valid standalone OpenType font.
-pub const PROFILE_OPENTYPE: &[u32] = &[
+const PROFILE_OPENTYPE: &[u32] = &[
     tag::CMAP,
     tag::HEAD,
     tag::HHEA,
@@ -62,7 +63,7 @@ pub const PROFILE_OPENTYPE: &[u32] = &[
 ];
 
 /// Full set of tables for a fully functional OpenType subset font (includes layout tables).
-pub const PROFILE_FULL: &[u32] = &[
+const PROFILE_FULL: &[u32] = &[
     tag::CMAP,
     tag::HEAD,
     tag::HHEA,
@@ -80,6 +81,96 @@ pub const PROFILE_FULL: &[u32] = &[
     tag::FPGM, // Font Program
     tag::PREP, // Control Value Program
 ];
+
+/// Constant array defining Unicode ranges and their corresponding bit index in the 128-bit mask.
+///
+/// Each tuple contains:
+/// - the start of the range (inclusive),
+/// - the end of the range (inclusive),
+/// - the bit index (i.e. which bit should be set).
+const UNICODE_RANGES: &[(u32, u32, u32)] = &[
+    (0x0000, 0x007F, 0),  // Basic Latin
+    (0x0080, 0x00FF, 1),  // Latin-1 Supplement
+    (0x0100, 0x017F, 2),  // Latin Extended-A
+    (0x0180, 0x024F, 3),  // Latin Extended-B
+    (0x0250, 0x02AF, 4),  // IPA Extensions
+    (0x02B0, 0x02FF, 5),  // Spacing Modifier Letters
+    (0x0300, 0x036F, 6),  // Combining Diacritical Marks
+    (0x0370, 0x03FF, 7),  // Greek and Coptic
+    (0x0400, 0x04FF, 9),  // Cyrillic
+    (0x0530, 0x058F, 10), // Armenian
+    (0x0590, 0x05FF, 11), // Hebrew
+    (0x0600, 0x06FF, 12), // Arabic
+    (0x0700, 0x074F, 13), // Syriac
+    (0x0750, 0x077F, 14), // Arabic Supplement
+    (0x0780, 0x07BF, 15), // Thaana
+    (0x07C0, 0x07FF, 16), // NKo
+    (0x0800, 0x083F, 17), // Samaritan
+    (0x0840, 0x085F, 18), // Mandaic
+    (0x0860, 0x086F, 19), // Syriac Supplement
+    (0x08A0, 0x08FF, 20), // Arabic Extended-A
+    (0x0900, 0x097F, 21), // Devanagari
+    (0x0980, 0x09FF, 22), // Bengali
+    (0x0A00, 0x0A7F, 23), // Gurmukhi
+    (0x0A80, 0x0AFF, 24), // Gujarati
+    (0x0B00, 0x0B7F, 25), // Oriya
+    (0x0B80, 0x0BFF, 26), // Tamil
+    (0x0C00, 0x0C7F, 27), // Telugu
+    (0x0C80, 0x0CFF, 28), // Kannada
+    (0x0D00, 0x0D7F, 29), // Malayalam
+    (0x0D80, 0x0DFF, 30), // Sinhala
+    (0x0E00, 0x0E7F, 31), // Thai
+    (0x0E80, 0x0EFF, 32), // Lao
+    (0x0F00, 0x0FFF, 33), // Tibetan
+    (0x1000, 0x109F, 34), // Myanmar
+    (0x10A0, 0x10FF, 35), // Georgian
+    (0x1100, 0x11FF, 36), // Hangul Jamo
+    (0x1E00, 0x1EFF, 37), // Latin Extended Additional
+    (0x1F00, 0x1FFF, 38), // Greek Extended
+];
+
+impl SubsetProfile {
+    /// Parses a custom subset profile from a string such as "gsub,vmtx,prep", includes the minimal tables automatically
+    pub fn parse_custom(s: &str) -> Self {
+        let mut tables = PROFILE_MINIMAL.to_vec();
+        let s = s.split(",").flat_map(|s| s.split_whitespace().into_iter()).collect::<BTreeSet<_>>();
+        for feature in s.iter() {
+            let newtag = match feature.to_lowercase().as_str() {
+                "cmap" => tag::CMAP,
+                "head" => tag::HEAD,
+                "hhea" => tag::HHEA,
+                "htmx" => tag::HMTX,
+                "maxp" => tag::MAXP,
+                "name" => tag::NAME,
+                "os/2" | "os2" | "os_2" => tag::OS_2,
+                "post" => tag::POST,
+                "gpos" => tag::GPOS,
+                "gsub" => tag::GSUB,
+                "vhea" => tag::VHEA,
+                "vtmx" => tag::VMTX,
+                "gdef" => tag::GDEF,
+                "cvt"  => tag::CVT,
+                "fpgm" => tag::FPGM,
+                "prep" => tag::PREP,
+                _ => continue,
+            };
+            tables.push(newtag);
+        }
+        tables.sort();
+        tables.dedup();
+        Self::Custom(tables)
+    }
+
+    /// Returns the tables needed to subset for this profile.
+    fn get_tables(&self) -> BTreeSet<u32> {
+        match self {
+            SubsetProfile::Minimal => PROFILE_MINIMAL.iter().copied().collect(),
+            SubsetProfile::OpenType => PROFILE_OPENTYPE.iter().copied().collect(),
+            SubsetProfile::Full => PROFILE_FULL.iter().copied().collect(),
+            SubsetProfile::Custom(items) => items.iter().copied().collect(),
+        }
+    }
+}
 
 /// Error type returned from subsetting.
 #[derive(Debug)]
@@ -131,6 +222,75 @@ struct OrderedTables {
     checksum: Wrapping<u32>,
 }
 
+fn subset_os2(
+    input: &Os2,
+    mappings: MappingsToKeep<OldIds>,
+) -> Os2 {
+
+    // Calculate new first and last Unicode codepoints.
+    let (new_first, new_last) = mappings.iter().fold((u32::MAX, 0u32), |(min, max), (ch, _)| {
+        let code = ch.as_u32();
+        (min.min(code), max.max(code))
+    });
+
+    // Compute the new ulUnicodeRange bitmask.
+    let new_unicode_mask: u128 = mappings.iter().fold(0, |mask, (ch, _)| {
+        mask | unicode_range_mask(ch.as_u32())
+    });
+
+    let new_ul_unicode_range1 = (new_unicode_mask & 0xFFFF_FFFF) as u32;
+    let new_ul_unicode_range2 = ((new_unicode_mask >> 32) & 0xFFFF_FFFF) as u32;
+    let new_ul_unicode_range3 = ((new_unicode_mask >> 64) & 0xFFFF_FFFF) as u32;
+    let new_ul_unicode_range4 = ((new_unicode_mask >> 96) & 0xFFFF_FFFF) as u32;
+
+
+    // TODO: Recalculate x_avg_char_width based on the subset glyph metrics.
+    let new_x_avg_char_width = recalc_avg_char_width().unwrap_or(os2.x_avg_char_width);
+    // recalc s_typo_ascender, s_typo_descender, s_typo_line_gap, us_win_ascent, us_win_descent
+    let new_version0 = os2.version0.clone();
+    // recalc ul_code_page_range1, ul_code_page_range2 if needed
+    let new_version1 = os2.version1.clone();
+     // recalc sx_height, s_cap_height, us_default_char, us_break_char, us_max_context
+    let new_version2to4 = os2.version2to4.clone();
+     // recalc us_lower_optical_point_size, us_upper_optical_point_size
+    let new_version5 = os2.version5.clone();
+
+    let fs_selection = os.fs_selection.clone();
+
+    Os2 {
+        version: os2.version,
+        x_avg_char_width: new_x_avg_char_width,
+        us_weight_class: new_weight_class,
+        us_width_class: new_width_class,
+        fs_type: os2.fs_type,
+        y_subscript_x_size: os2.y_subscript_x_size,
+        y_subscript_y_size: os2.y_subscript_y_size,
+        y_subscript_x_offset: os2.y_subscript_x_offset,
+        y_subscript_y_offset: os2.y_subscript_y_offset,
+        y_superscript_x_size: os2.y_superscript_x_size,
+        y_superscript_y_size: os2.y_superscript_y_size,
+        y_superscript_x_offset: os2.y_superscript_x_offset,
+        y_superscript_y_offset: os2.y_superscript_y_offset,
+        y_strikeout_size: os2.y_strikeout_size,
+        y_strikeout_position: os2.y_strikeout_position,
+        s_family_class: os2.s_family_class,
+        panose: new_panose,
+        ul_unicode_range1: new_ul_unicode_range1,
+        ul_unicode_range2: new_ul_unicode_range2,
+        ul_unicode_range3: new_ul_unicode_range3,
+        ul_unicode_range4: new_ul_unicode_range4,
+        ach_vend_id: os2.ach_vend_id,
+        fs_selection: new_fs_selection,
+        us_first_char_index: new_first as u16,
+        us_last_char_index: new_last as u16,
+        version0: new_version0,
+        version1: new_version1,
+        version2to4: new_version2to4,
+        version5: new_version5,
+    }
+}
+
+
 /// Subset this font so that it only contains the glyphs with the supplied `glyph_ids`.
 ///
 /// `glyph_ids` requirements:
@@ -143,7 +303,7 @@ struct OrderedTables {
 pub fn subset(
     provider: &impl FontTableProvider,
     glyph_ids: &[u16],
-    profile: SubsetProfile,
+    profile: &SubsetProfile,
 ) -> Result<Vec<u8>, SubsetError> {
     let mappings_to_keep = MappingsToKeep::new(
         provider, 
@@ -185,7 +345,7 @@ pub fn subset(
 fn subset_ttf(
     provider: &impl FontTableProvider,
     glyph_ids: &[u16],
-    profile: SubsetProfile,
+    profile: &SubsetProfile,
     cmap_strategy: CmapStrategy,
 ) -> Result<Vec<u8>, ReadWriteError> {
     let head = ReadScope::new(&provider.read_table_data(tag::HEAD)?).read::<HeadTable>()?;
@@ -274,7 +434,7 @@ fn subset_cff(
     provider: &impl FontTableProvider,
     glyph_ids: &[u16],
     mappings_to_keep: MappingsToKeep<OldIds>,
-    profile: SubsetProfile,
+    profile: &SubsetProfile,
     convert_cff_to_cid_if_more_than_255_glyphs: bool,
 ) -> Result<Vec<u8>, SubsetError> {
     let cff_data = provider.read_table_data(tag::CFF)?;
@@ -311,7 +471,7 @@ fn subset_cff2(
     glyph_ids: &[u16],
     mappings_to_keep: MappingsToKeep<OldIds>,
     include_fstype: bool,
-    profile: SubsetProfile,
+    profile: &SubsetProfile,
     output_format: OutputFormat,
 ) -> Result<Vec<u8>, SubsetError> {
     let cff2_data = provider.read_table_data(tag::CFF2)?;
@@ -673,6 +833,20 @@ impl FontBuilderWithHead {
 /// Calculate the maximum power of 2 that is <= num
 fn max_power_of_2(num: u16) -> u16 {
     15u16.saturating_sub(num.leading_zeros() as u16)
+}
+
+/// Map a Unicode codepoint to a 128-bit mask for the ulUnicodeRange field.
+///
+/// This function iterates over the array of defined ranges and returns a mask with the bit
+/// corresponding to the Unicode block set if the input codepoint falls within that range.
+/// If no range matches, it returns 0.
+fn unicode_range_mask(ch: u32) -> u128 {
+    for &(start, end, bit) in UNICODE_RANGES.iter() {
+        if (start..=end).contains(&ch) {
+            return 1 << bit;
+        }
+    }
+    0
 }
 
 /// Prince specific subsetting behaviour.
@@ -1328,7 +1502,7 @@ mod tests {
         match subset(
             &opentype_file.table_provider(0).unwrap(), 
             &mut glyph_ids, 
-            SubsetProfile::Minimal
+            &SubsetProfile::Minimal
         ) {
             Err(SubsetError::Parse(ParseError::BadIndex)) => {}
             err => panic!(
@@ -1349,7 +1523,7 @@ mod tests {
             subset(
                 &opentype_file.table_provider(0).unwrap(), 
                 &mut glyph_ids, 
-                SubsetProfile::Minimal
+                &SubsetProfile::Minimal
             ).unwrap();
 
         let opentype_file = ReadScope::new(&subset_font_data)
@@ -1379,7 +1553,7 @@ mod tests {
         let subset_font_data = subset_ttf(
             &opentype_file.table_provider(0).unwrap(),
             &mut glyph_ids,
-            SubsetProfile::Minimal,
+            &SubsetProfile::Minimal,
             CmapStrategy::Omit,
         )
         .unwrap();
@@ -1439,7 +1613,7 @@ mod tests {
 
         // Subset the CFF2, producing CFF. Since there is only two glyphs in the subset font it
         // will produce a Type 1 CFF font.
-        let new_font = subset(&provider, &[0, 1], SubsetProfile::Minimal).unwrap();
+        let new_font = subset(&provider, &[0, 1], &SubsetProfile::Minimal).unwrap();
 
         // Read it back
         let subset_otf = ReadScope::new(&new_font)
@@ -1467,7 +1641,7 @@ mod tests {
         // Subset the CFF2, producing CFF. Since there is more than 255 glyphs in the subset font it
         // will produce a CID-keyed CFF font.
         let glyph_ids = (0..=256).collect::<Vec<_>>();
-        let new_font = subset(&provider, &glyph_ids, SubsetProfile::Minimal).unwrap();
+        let new_font = subset(&provider, &glyph_ids, &SubsetProfile::Minimal).unwrap();
 
         // Read it back
         let subset_otf = ReadScope::new(&new_font)

--- a/src/subset.rs
+++ b/src/subset.rs
@@ -17,7 +17,7 @@ use crate::cff::cff2::{OutputFormat, CFF2};
 use crate::cff::{CFFError, SubsetCFF, CFF};
 use crate::error::{ParseError, ReadWriteError, WriteError};
 use crate::post::PostTable;
-use crate::tables::cmap::subset::{CmapStrategy, CmapTarget, MappingsToKeep, NewIds, OldIds};
+use crate::tables::cmap::subset::{CmapStrategy, MappingsToKeep, NewIds, OldIds};
 use crate::tables::cmap::{owned, EncodingId, PlatformId};
 use crate::tables::glyf::GlyfTable;
 use crate::tables::loca::{self, LocaTable};
@@ -28,30 +28,24 @@ use crate::tables::{
 };
 use crate::{checksum, tag};
 
-/// Profiles for controlling the tables included in subset fonts.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum SubsetProfile {
-    /// Minimal profile, suitable for PDF embedding (smallest file size).
-    Minimal,
-    /// Web profile, includes minimum tables for a valid standalone OpenType font.
-    Web,
-    /// Full profile, includes all relevant tables for a fully functional subset font.
-    Full,
-    /// Custom profile, allows specifying a list of tables to include.
-    Custom(Vec<u32>),
-}
+/// Minimal set of tables, suitable for PDF embedding
+const PROFILE_PDF: &[u32] = &[
+    tag::CMAP,
+    tag::CVT,
+    tag::FPGM,
+    tag::HHEA,
+    tag::HMTX,
+    tag::MAXP,
+    tag::NAME,
+    tag::OS_2,
+    tag::POST,
+    tag::PREP,
+];
 
-impl Default for SubsetProfile {
-    fn default() -> Self {
-        SubsetProfile::Minimal
-    }
-}
-
-/// Minimal set of tables for PDF embedding (current behaviour).
-const PROFILE_MINIMAL: &[u32] = &[]; // Define minimal table set if any
-
-/// Minimum tables required for a valid standalone OpenType font.
-const PROFILE_WEB: &[u32] = &[
+/// Minimum tables required for a valid OpenType font.
+///
+/// <https://learn.microsoft.com/en-us/typography/opentype/spec/otff#required-tables>
+const PROFILE_MINIMAL: &[u32] = &[
     tag::CMAP,
     tag::HEAD,
     tag::HHEA,
@@ -62,7 +56,7 @@ const PROFILE_WEB: &[u32] = &[
     tag::POST,
 ];
 
-/// Full set of tables for a fully functional OpenType subset font (includes layout tables).
+/// Full set of tables for a valid OpenType subset font (includes layout tables).
 const PROFILE_FULL: &[u32] = &[
     tag::CMAP,
     tag::HEAD,
@@ -81,6 +75,36 @@ const PROFILE_FULL: &[u32] = &[
     tag::FPGM, // Font Program
     tag::PREP, // Control Value Program
 ];
+
+/// Profiles for controlling the tables included in subset fonts.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SubsetProfile {
+    /// Minimal set of tables, suitable for PDF embedding
+    Pdf,
+    /// Minimum tables required for a valid OpenType font.
+    Minimal,
+    /// Full profile, includes all relevant tables for a fully functional subset font.
+    Full,
+    /// Custom profile, allows specifying a list of tables to include.
+    Custom(Vec<u32>),
+}
+
+/// Target cmap format to use when subsetting
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Default)]
+pub enum CmapTarget {
+    /// Use the smallest suitable cmap
+    #[default]
+    Unrestricted,
+    /// Use a Mac Roman cmap
+    ///
+    /// Characters outside the Mac Roman character set will be omitted.
+    MacRoman,
+    /// Use a Unicode cmap format
+    ///
+    /// Select this option if targeting the web as browsers reject fonts with only a
+    /// Mac Roman cmap.
+    Unicode,
+}
 
 impl SubsetProfile {
     /// Parses a custom subset profile from a string
@@ -131,8 +155,8 @@ impl SubsetProfile {
     /// Returns the tables needed to subset for this profile.
     fn get_tables(&self) -> &[u32] {
         match self {
+            SubsetProfile::Pdf => PROFILE_PDF,
             SubsetProfile::Minimal => PROFILE_MINIMAL,
-            SubsetProfile::Web => PROFILE_WEB,
             SubsetProfile::Full => PROFILE_FULL,
             SubsetProfile::Custom(items) => items,
         }
@@ -245,14 +269,8 @@ pub fn subset(
     provider: &impl FontTableProvider,
     glyph_ids: &[u16],
     profile: &SubsetProfile,
+    cmap_target: CmapTarget,
 ) -> Result<Vec<u8>, SubsetError> {
-    let cmap_target = if profile == &SubsetProfile::Web {
-        // Fonts used on the web must have a Unicode CMAP. Fonts with only a Mac Roman CMAP
-        // are rejected.
-        CmapTarget::Unicode
-    } else {
-        CmapTarget::Unrestricted
-    };
     let mappings_to_keep = MappingsToKeep::new(provider, glyph_ids, cmap_target)?;
     if provider.has_table(tag::CFF) {
         subset_cff(provider, glyph_ids, mappings_to_keep, true, profile)
@@ -473,6 +491,7 @@ fn build_otf(
     hmtx: &HmtxTable<'_>,
     profile: &SubsetProfile,
 ) -> Result<Vec<u8>, SubsetError> {
+    // Get profile tables
     let profile_tables = profile.get_tables();
 
     // Get the OS/2 table if needed
@@ -823,8 +842,8 @@ pub mod prince {
         CFF,
     };
     use crate::cff::cff2::{OutputFormat, CFF2};
-    use crate::subset::SubsetProfile;
-    use crate::tables::cmap::subset::{CmapStrategy, CmapTarget};
+    use crate::subset::{CmapTarget, SubsetProfile};
+    use crate::tables::cmap::subset::CmapStrategy;
     use std::ffi::c_int;
 
     /// This enum describes the desired cmap generation and maps to the `cmap_target` type in Prince
@@ -985,7 +1004,7 @@ impl std::error::Error for SubsetError {}
 mod tests {
     use super::*;
     use crate::font_data::FontData;
-    use crate::tables::cmap::CmapSubtable;
+    use crate::tables::cmap::{Cmap, CmapSubtable};
     use crate::tables::glyf::{
         BoundingBox, CompositeGlyph, CompositeGlyphArgument, CompositeGlyphComponent,
         CompositeGlyphFlag, GlyfRecord, Glyph, Point, SimpleGlyph, SimpleGlyphFlag,
@@ -1468,7 +1487,8 @@ mod tests {
         match subset(
             &opentype_file.table_provider(0).unwrap(),
             &mut glyph_ids,
-            &SubsetProfile::Minimal,
+            &SubsetProfile::Pdf,
+            CmapTarget::Unrestricted,
         ) {
             Err(SubsetError::Parse(ParseError::BadIndex)) => {}
             err => panic!(
@@ -1488,7 +1508,8 @@ mod tests {
         let subset_font_data = subset(
             &opentype_file.table_provider(0).unwrap(),
             &mut glyph_ids,
-            &SubsetProfile::Minimal,
+            &SubsetProfile::Pdf,
+            CmapTarget::Unrestricted,
         )
         .unwrap();
 
@@ -1520,7 +1541,7 @@ mod tests {
             &opentype_file.table_provider(0).unwrap(),
             &mut glyph_ids,
             CmapStrategy::Omit,
-            &SubsetProfile::Minimal,
+            &SubsetProfile::Pdf,
         )
         .unwrap();
 
@@ -1579,7 +1600,13 @@ mod tests {
 
         // Subset the CFF2, producing CFF. Since there is only two glyphs in the subset font it
         // will produce a Type 1 CFF font.
-        let new_font = subset(&provider, &[0, 1], &SubsetProfile::Minimal).unwrap();
+        let new_font = subset(
+            &provider,
+            &[0, 1],
+            &SubsetProfile::Pdf,
+            CmapTarget::Unrestricted,
+        )
+        .unwrap();
 
         // Read it back
         let subset_otf = ReadScope::new(&new_font)
@@ -1607,7 +1634,13 @@ mod tests {
         // Subset the CFF2, producing CFF. Since there is more than 255 glyphs in the subset font it
         // will produce a CID-keyed CFF font.
         let glyph_ids = (0..=256).collect::<Vec<_>>();
-        let new_font = subset(&provider, &glyph_ids, &SubsetProfile::Minimal).unwrap();
+        let new_font = subset(
+            &provider,
+            &glyph_ids,
+            &SubsetProfile::Pdf,
+            CmapTarget::Unrestricted,
+        )
+        .unwrap();
 
         // Read it back
         let subset_otf = ReadScope::new(&new_font)
@@ -1628,15 +1661,92 @@ mod tests {
     }
 
     #[test]
+    fn test_subset_with_os2_and_unicode_cmap() {
+        // Test string to use for the font subset
+        let test_string = "hello world";
+
+        // Load the font
+        let buffer = read_fixture("tests/fonts/opentype/Klei.otf");
+        let opentype_file = ReadScope::new(&buffer).read::<OpenTypeFont<'_>>().unwrap();
+        let provider = opentype_file.table_provider(0).unwrap();
+
+        // Create a font instance to access cmap
+        let font = Font::new(provider).unwrap();
+
+        // Get the cmap subtable for unicode mapping
+        let cmap_data = font.cmap_subtable_data();
+        let cmap_subtable = ReadScope::new(cmap_data).read::<CmapSubtable>().unwrap();
+
+        // Map characters to glyph IDs
+        let mut glyph_ids = vec![0]; // Always include glyph 0 (.notdef)
+
+        for c in test_string.chars() {
+            if let Ok(Some(glyph_id)) = cmap_subtable.map_glyph(c as u32) {
+                glyph_ids.push(glyph_id);
+            }
+        }
+
+        // Sort and deduplicate glyph IDs
+        glyph_ids.sort();
+        glyph_ids.dedup();
+
+        // Subset the font
+        let subset_buffer = subset(
+            &font.font_table_provider,
+            &glyph_ids,
+            &SubsetProfile::Minimal,
+            CmapTarget::Unicode,
+        )
+        .unwrap();
+
+        // Validate that the OS/2 table is present in the subsetted font
+        let subset_otf = ReadScope::new(&subset_buffer)
+            .read::<OpenTypeFont<'_>>()
+            .unwrap();
+        let subset_provider = subset_otf.table_provider(0).unwrap();
+
+        // Check that OS/2 table exists
+        assert!(
+            subset_provider.has_table(tag::OS_2),
+            "Subset font is missing the OS/2 table."
+        );
+
+        // Read back the cmap and check that it's a unicode cmap
+        let cmap_data = font.font_table_provider.read_table_data(tag::CMAP).unwrap();
+        let cmap = ReadScope::new(&cmap_data).read::<Cmap<'_>>().unwrap();
+        assert!(
+            cmap.find_subtable(PlatformId::UNICODE, EncodingId::UNICODE_BMP)
+                .is_some(),
+            "subset font does not have expected Unicode cmap"
+        );
+    }
+
+    #[test]
     fn parse_custom_profile() {
         let tables = "abcd,OS/2 os2,GSUB".to_string();
-        let custom = SubsetProfile::parse_custom(tables).unwrap();
-        let expected = SubsetProfile::Custom(vec![
-            // abcd comes last because uppercase sorts before lowercase
+        let custom = SubsetProfile::parse_custom(tables)
+            .unwrap()
+            .get_tables()
+            .iter()
+            .copied()
+            .map(|table| DisplayTag(table).to_string())
+            .collect::<Vec<_>>();
+        let expected = vec![
             tag::GSUB,
             tag::OS_2,
+            // abcd comes last because uppercase sorts before lowercase
             tag!(b"abcd"),
-        ]);
+            tag::CMAP,
+            tag::HEAD,
+            tag::HHEA,
+            tag::HMTX,
+            tag::MAXP,
+            tag::NAME,
+            tag::POST,
+        ]
+        .into_iter()
+        .map(|table| DisplayTag(table).to_string())
+        .collect::<Vec<_>>();
 
         assert_eq!(custom, expected)
     }

--- a/src/tables/cmap/subset.rs
+++ b/src/tables/cmap/subset.rs
@@ -8,7 +8,7 @@ use crate::binary::read::ReadScope;
 use crate::error::ParseError;
 use crate::font::Encoding;
 use crate::macroman::{char_to_macroman, is_macroman, macroman_to_char};
-use crate::subset::SubsetGlyphs;
+use crate::subset::{CmapTarget, SubsetGlyphs};
 use crate::tables::cmap::{owned, Cmap, EncodingId, PlatformId, SequentialMapGroup};
 use crate::tables::os2::{self, Os2};
 use crate::tables::{cmap, FontTableProvider};
@@ -39,15 +39,6 @@ enum CharExistence {
 enum Character {
     Unicode(char),
     Symbol(u32),
-}
-
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
-pub(crate) enum CmapTarget {
-    Unrestricted,
-    // Variant is only used when the `prince` feature is enabled.
-    #[allow(unused)]
-    MacRoman,
-    Unicode,
 }
 
 /// The strategy to use to generate a cmap table for the subset font

--- a/src/tables/os2.rs
+++ b/src/tables/os2.rs
@@ -17,6 +17,7 @@ use crate::tables::Fixed;
 /// `OS/2` table
 ///
 /// <https://docs.microsoft.com/en-us/typography/opentype/spec/os2>
+#[derive(Clone)]
 pub struct Os2 {
     pub version: u16,
     pub x_avg_char_width: i16,
@@ -54,6 +55,7 @@ pub struct Os2 {
     pub version5: Option<Version5>,
 }
 
+#[derive(Clone)]
 pub struct Version0 {
     pub s_typo_ascender: i16,
     pub s_typo_descender: i16,
@@ -62,11 +64,13 @@ pub struct Version0 {
     pub us_win_descent: u16,
 }
 
+#[derive(Clone)]
 pub struct Version1 {
     pub ul_code_page_range1: u32,
     pub ul_code_page_range2: u32,
 }
 
+#[derive(Clone)]
 pub struct Version2to4 {
     pub s_x_height: i16,
     pub s_cap_height: i16,
@@ -75,6 +79,7 @@ pub struct Version2to4 {
     pub us_max_context: u16,
 }
 
+#[derive(Clone)]
 pub struct Version5 {
     pub us_lower_optical_point_size: u16,
     pub us_upper_optical_point_size: u16,
@@ -388,6 +393,67 @@ impl WriteBinary<&Self> for Version5 {
         U16Be::write(ctxt, table.us_upper_optical_point_size)?;
         Ok(())
     }
+}
+
+/// Constant array defining Unicode ranges and their corresponding bit index in the 128-bit mask.
+///
+/// Each tuple contains:
+/// - the start of the range (inclusive),
+/// - the end of the range (inclusive),
+/// - the bit index (i.e. which bit should be set).
+const UNICODE_RANGES: &[(u32, u32, u32)] = &[
+    (0x0000, 0x007F, 0),  // Basic Latin
+    (0x0080, 0x00FF, 1),  // Latin-1 Supplement
+    (0x0100, 0x017F, 2),  // Latin Extended-A
+    (0x0180, 0x024F, 3),  // Latin Extended-B
+    (0x0250, 0x02AF, 4),  // IPA Extensions
+    (0x02B0, 0x02FF, 5),  // Spacing Modifier Letters
+    (0x0300, 0x036F, 6),  // Combining Diacritical Marks
+    (0x0370, 0x03FF, 7),  // Greek and Coptic
+    (0x0400, 0x04FF, 9),  // Cyrillic
+    (0x0530, 0x058F, 10), // Armenian
+    (0x0590, 0x05FF, 11), // Hebrew
+    (0x0600, 0x06FF, 12), // Arabic
+    (0x0700, 0x074F, 13), // Syriac
+    (0x0750, 0x077F, 14), // Arabic Supplement
+    (0x0780, 0x07BF, 15), // Thaana
+    (0x07C0, 0x07FF, 16), // NKo
+    (0x0800, 0x083F, 17), // Samaritan
+    (0x0840, 0x085F, 18), // Mandaic
+    (0x0860, 0x086F, 19), // Syriac Supplement
+    (0x08A0, 0x08FF, 20), // Arabic Extended-A
+    (0x0900, 0x097F, 21), // Devanagari
+    (0x0980, 0x09FF, 22), // Bengali
+    (0x0A00, 0x0A7F, 23), // Gurmukhi
+    (0x0A80, 0x0AFF, 24), // Gujarati
+    (0x0B00, 0x0B7F, 25), // Oriya
+    (0x0B80, 0x0BFF, 26), // Tamil
+    (0x0C00, 0x0C7F, 27), // Telugu
+    (0x0C80, 0x0CFF, 28), // Kannada
+    (0x0D00, 0x0D7F, 29), // Malayalam
+    (0x0D80, 0x0DFF, 30), // Sinhala
+    (0x0E00, 0x0E7F, 31), // Thai
+    (0x0E80, 0x0EFF, 32), // Lao
+    (0x0F00, 0x0FFF, 33), // Tibetan
+    (0x1000, 0x109F, 34), // Myanmar
+    (0x10A0, 0x10FF, 35), // Georgian
+    (0x1100, 0x11FF, 36), // Hangul Jamo
+    (0x1E00, 0x1EFF, 37), // Latin Extended Additional
+    (0x1F00, 0x1FFF, 38), // Greek Extended
+];
+
+/// Map a Unicode codepoint to a 128-bit mask for the ulUnicodeRange field.
+///
+/// This function iterates over the array of defined ranges and returns a mask with the bit
+/// corresponding to the Unicode block set if the input codepoint falls within that range.
+/// If no range matches, it returns 0.
+pub(crate) fn unicode_range_mask(ch: u32) -> u128 {
+    for &(start, end, bit) in UNICODE_RANGES.iter() {
+        if (start..=end).contains(&ch) {
+            return 1 << bit;
+        }
+    }
+    0
 }
 
 #[cfg(test)]

--- a/src/variations.rs
+++ b/src/variations.rs
@@ -17,7 +17,7 @@ use crate::cff::cff2::CFF2;
 use crate::cff::CFFError;
 use crate::error::{ParseError, ReadWriteError, WriteError};
 use crate::post::PostTable;
-use crate::subset::FontBuilder;
+use crate::subset::{FontBuilder, TableFilter};
 use crate::tables::glyf::{BoundingBox, GlyfRecord, GlyfTable, Glyph};
 use crate::tables::loca::LocaTable;
 use crate::tables::os2::{FsSelection, Os2};
@@ -391,8 +391,8 @@ pub fn instance(
 
     // Build the new font
     let mut builder = match glyph_data {
-        GlyphData::Cff2(_) => FontBuilder::new(CFF_MAGIC),
-        GlyphData::Glyf(_) => FontBuilder::new(TRUE_MAGIC),
+        GlyphData::Cff2(_) => FontBuilder::new(CFF_MAGIC, TableFilter::All),
+        GlyphData::Glyf(_) => FontBuilder::new(TRUE_MAGIC, TableFilter::All),
     };
     if let Some(cvt) = cvt {
         builder.add_table::<_, CvtTable<'_>>(tag::CVT, &cvt, ())?;

--- a/tests/cff.rs
+++ b/tests/cff.rs
@@ -17,7 +17,7 @@ use allsorts::cff::{
 use allsorts::subset::subset;
 use allsorts::tables::{OpenTypeData, OpenTypeFont};
 use allsorts::tag;
-
+use allsorts::subset::SubsetProfile;
 use crate::common::read_fixture;
 
 #[test]
@@ -243,7 +243,11 @@ fn test_subset_cff_cid() {
         2522, 5221,
     ];
     assert_eq!(
-        subset(&opentype_file.table_provider(0).unwrap(), &mut glyph_ids,)
+        subset(
+            &opentype_file.table_provider(0).unwrap(), 
+            &mut glyph_ids, 
+            SubsetProfile::Minimal
+        )
             .unwrap()
             .len(),
         7900
@@ -256,7 +260,11 @@ fn test_subset_cff_type1() {
     let opentype_file = ReadScope::new(&buffer).read::<OpenTypeFont<'_>>().unwrap();
     let mut glyph_ids = [0, 1, 53, 66, 67, 70, 72, 73, 74, 79, 84, 85, 86];
     assert_eq!(
-        subset(&opentype_file.table_provider(0).unwrap(), &mut glyph_ids,)
+        subset(
+            &opentype_file.table_provider(0).unwrap(), 
+            &mut glyph_ids, 
+            SubsetProfile::Minimal
+        )
             .unwrap()
             .len(),
         26576
@@ -270,7 +278,11 @@ fn test_subset_cff_type1_iso_adobe() {
     let buffer = read_fixture("tests/fonts/opentype/Klei.otf");
     let opentype_file = ReadScope::new(&buffer).read::<OpenTypeFont<'_>>().unwrap();
     let mut glyph_ids = [0, 1, 2, 3, 4, 5, 6, 7];
-    let subset_buffer = subset(&opentype_file.table_provider(0).unwrap(), &mut glyph_ids).unwrap();
+    let subset_buffer = subset(
+        &opentype_file.table_provider(0).unwrap(), 
+        &mut glyph_ids, 
+        SubsetProfile::Minimal
+    ).unwrap();
     let scope = ReadScope::new(&subset_buffer);
 
     let otf = scope.read::<OpenTypeFont>().unwrap();

--- a/tests/cff.rs
+++ b/tests/cff.rs
@@ -246,7 +246,7 @@ fn test_subset_cff_cid() {
         subset(
             &opentype_file.table_provider(0).unwrap(), 
             &mut glyph_ids, 
-            SubsetProfile::Minimal
+            &SubsetProfile::Minimal
         )
             .unwrap()
             .len(),
@@ -263,7 +263,7 @@ fn test_subset_cff_type1() {
         subset(
             &opentype_file.table_provider(0).unwrap(), 
             &mut glyph_ids, 
-            SubsetProfile::Minimal
+            &SubsetProfile::Minimal
         )
             .unwrap()
             .len(),
@@ -281,7 +281,7 @@ fn test_subset_cff_type1_iso_adobe() {
     let subset_buffer = subset(
         &opentype_file.table_provider(0).unwrap(), 
         &mut glyph_ids, 
-        SubsetProfile::Minimal
+        &SubsetProfile::Minimal
     ).unwrap();
     let scope = ReadScope::new(&subset_buffer);
 

--- a/tests/cff.rs
+++ b/tests/cff.rs
@@ -9,16 +9,124 @@ use std::fmt::Write;
 
 use itertools::Itertools;
 
+use crate::common::read_fixture;
 use allsorts::binary::read::ReadScope;
 use allsorts::binary::write::{WriteBinary, WriteBuffer};
 use allsorts::cff::{
     CFFVariant, Charset, Dict, DictDefault, FontDict, Operand, Operator, CFF, MAX_OPERANDS,
 };
-use allsorts::subset::subset;
+use allsorts::subset::{subset, SubsetProfile};
 use allsorts::tables::{OpenTypeData, OpenTypeFont};
 use allsorts::tag;
-use allsorts::subset::SubsetProfile;
-use crate::common::read_fixture;
+
+#[test]
+fn test_subset_with_os2_table() {
+    use allsorts::font::Font;
+    use allsorts::tables::cmap::CmapSubtable;
+    use allsorts::tables::FontTableProvider;
+
+    // Test string to use for the font subset
+    let test_string = "hello world";
+
+    // Load the font
+    let buffer = read_fixture("tests/fonts/opentype/Klei.otf");
+    let opentype_file = ReadScope::new(&buffer).read::<OpenTypeFont<'_>>().unwrap();
+    let provider = opentype_file.table_provider(0).unwrap();
+    let provider2 = opentype_file.table_provider(0).unwrap();
+
+    // Create a font instance to access cmap
+    let font = Font::new(provider).unwrap();
+
+    // Get the cmap subtable for unicode mapping
+    let cmap_data = font.cmap_subtable_data();
+    let cmap_subtable = ReadScope::new(cmap_data).read::<CmapSubtable>().unwrap();
+
+    // Map characters to glyph IDs
+    let mut glyph_ids = vec![0]; // Always include glyph 0 (.notdef)
+
+    for c in test_string.chars() {
+        if let Ok(Some(glyph_id)) = cmap_subtable.map_glyph(c as u32) {
+            if !glyph_ids.contains(&glyph_id) {
+                glyph_ids.push(glyph_id);
+            }
+        }
+    }
+
+    // Sort and deduplicate glyph IDs
+    glyph_ids.sort();
+    glyph_ids.dedup();
+
+    println!("Using glyph IDs: {:?}", glyph_ids);
+
+    // Subset the font
+    let subset_buffer = subset(&provider2, &glyph_ids, &SubsetProfile::Web).unwrap();
+
+    // Validate that the OS/2 table is present in the subsetted font
+    let subset_otf = ReadScope::new(&subset_buffer)
+        .read::<OpenTypeFont<'_>>()
+        .unwrap();
+    let subset_provider = subset_otf.table_provider(0).unwrap();
+
+    // Check that OS/2 table exists
+    assert!(
+        subset_provider.has_table(tag::OS_2),
+        "Subset font is missing the OS/2 table. Use Profile::Web for web compatibility."
+    );
+
+    // NOTE: For manual testing, if the subsetted font works in a browser,
+    // you can add base64 to the Cargo.toml and then comment this code.
+    //
+    // Manual verification works. If your browser complains about an
+    // "invalid / missing cmap" table that's because browsers don't accept
+    // a MacRome (type 0) encoded CMAP, because it's a very old Apple format.
+    // Browsers need type 4 or higher. See EncodingRecord::from_mappings in
+    // tables/cmap/subset.rs and https://github.com/yeslogic/allsorts/issues/111
+
+    /*
+
+    use base64::{Engine as _, engine::general_purpose};
+    use std::fs::File;
+    use std::io::Write;
+
+    // Output an HTML file with the test string using the subsetted font
+    let base64_font = base64::prelude::BASE64_STANDARD.encode(&subset_buffer);
+    let html = format!(r#"<!DOCTYPE html>
+        <html>
+        <head>
+            <title>Font Subset Test</title>
+            <style>
+                @font-face {{
+                    font-family: 'SubsetFont';
+                    src: url('data:font/otf;base64,{}') format('opentype');
+                }}
+                .test-text {{
+                    font-family: 'SubsetFont', sans-serif;
+                    font-size: 24px;
+                }}
+                .fallback {{
+                    font-family: sans-serif;
+                    font-size: 24px;
+                }}
+            </style>
+        </head>
+        <body>
+            <h1>Font Subset Test</h1>
+            <p>The text below should display in the subsetted font:</p>
+            <p class="test-text">{}</p>
+            <p>This is fallback text:</p>
+            <p class="fallback">{}</p>
+        </body>
+    </html>"#, base64_font, test_string, test_string);
+
+    // Write the HTML to a file
+    let output_path = "./subset_font_test.html";
+    let mut file = File::create(output_path).unwrap();
+    file.write_all(html.as_bytes()).unwrap();
+
+    println!("Created {} - open in a browser to verify the font works", output_path);
+
+    */
+}
 
 #[test]
 fn test_read_write_cff_cid() {
@@ -244,12 +352,12 @@ fn test_subset_cff_cid() {
     ];
     assert_eq!(
         subset(
-            &opentype_file.table_provider(0).unwrap(), 
-            &mut glyph_ids, 
+            &opentype_file.table_provider(0).unwrap(),
+            &mut glyph_ids,
             &SubsetProfile::Minimal
         )
-            .unwrap()
-            .len(),
+        .unwrap()
+        .len(),
         7900
     );
 }
@@ -261,12 +369,12 @@ fn test_subset_cff_type1() {
     let mut glyph_ids = [0, 1, 53, 66, 67, 70, 72, 73, 74, 79, 84, 85, 86];
     assert_eq!(
         subset(
-            &opentype_file.table_provider(0).unwrap(), 
-            &mut glyph_ids, 
+            &opentype_file.table_provider(0).unwrap(),
+            &mut glyph_ids,
             &SubsetProfile::Minimal
         )
-            .unwrap()
-            .len(),
+        .unwrap()
+        .len(),
         26576
     );
 }
@@ -279,10 +387,11 @@ fn test_subset_cff_type1_iso_adobe() {
     let opentype_file = ReadScope::new(&buffer).read::<OpenTypeFont<'_>>().unwrap();
     let mut glyph_ids = [0, 1, 2, 3, 4, 5, 6, 7];
     let subset_buffer = subset(
-        &opentype_file.table_provider(0).unwrap(), 
-        &mut glyph_ids, 
-        &SubsetProfile::Minimal
-    ).unwrap();
+        &opentype_file.table_provider(0).unwrap(),
+        &mut glyph_ids,
+        &SubsetProfile::Minimal,
+    )
+    .unwrap();
     let scope = ReadScope::new(&subset_buffer);
 
     let otf = scope.read::<OpenTypeFont>().unwrap();


### PR DESCRIPTION
This is a continuation of #112. It reduces the scope to support @fschutt's use-case as well as Prince's use case. Future work that added support for subsetting layout tables (`GSUB`/`GPOS` #64) would allow the "full" profile to be brought back, which would address #27, but this is not planned at the moment.

In addition to profiles, the `CmapTarget` is exposed, which allows the cmap to be limited to Unicode cmaps. These are compatible with web browsers that reject fonts with only a Mac Roman cmap. 

Closes #111 