### PR TITLE
Move GlyphId to lib.rs

### DIFF
--- a/src/cff.rs
+++ b/src/cff.rs
@@ -29,8 +29,9 @@ use crate::binary::{I16Be, I32Be, U16Be, U24Be, U32Be, U8};
 use crate::error::{ParseError, WriteError};
 use crate::tables::variable_fonts::{ItemVariationStore, OwnedTuple};
 use crate::variations::VariationError;
+use crate::GlyphId;
 use cff2::BlendOperand;
-use charstring::{ArgumentsStack, GlyphId, TryNumFrom};
+use charstring::{ArgumentsStack, TryNumFrom};
 pub use subset::SubsetCFF;
 
 /// Maximum number of operands in Top DICT, Font DICTs, Private DICTs and CharStrings.

--- a/src/cff/charstring.rs
+++ b/src/cff/charstring.rs
@@ -15,6 +15,7 @@ use crate::cff::cff2::BlendOperand;
 use crate::error::{ParseError, WriteError};
 use crate::tables::variable_fonts::{ItemVariationStore, OwnedTuple};
 use crate::tables::Fixed;
+use crate::GlyphId;
 
 use super::{cff2, CFFError, CFFFont, CFFVariant, MaybeOwnedIndex, Operator};
 
@@ -37,8 +38,6 @@ pub(crate) trait TryNumFrom<T>: Sized {
     /// Casts between numeric types.
     fn try_num_from(_: T) -> Option<Self>;
 }
-
-pub(crate) type GlyphId = u16;
 
 pub(crate) struct UsedSubrs {
     pub(crate) global_subr_used: FxHashSet<usize>,

--- a/src/font.rs
+++ b/src/font.rs
@@ -29,7 +29,7 @@ use crate::tables::variable_fonts::fvar::{FvarAxisCount, FvarTable, Tuple, Varia
 use crate::tables::{kern, FontTableProvider, HeadTable, HheaTable, MaxpTable};
 use crate::unicode::{self, VariationSelector};
 use crate::variations::{AxisNamesError, NamedAxis};
-use crate::{glyph_info, tag, variations};
+use crate::{glyph_info, tag, variations, GlyphId};
 use crate::{gpos, gsub, DOTTED_CIRCLE};
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
@@ -600,7 +600,7 @@ impl<T: FontTableProvider> Font<T> {
     ///   all bit depths then use `BitDepth::ThirtyTwo`.
     pub fn lookup_glyph_image(
         &mut self,
-        glyph_index: u16,
+        glyph_index: GlyphId,
         target_ppem: u16,
         max_bit_depth: BitDepth,
     ) -> Result<Option<BitmapGlyph>, ParseError> {
@@ -652,7 +652,7 @@ impl<T: FontTableProvider> Font<T> {
         sbix: &tables::Sbix,
         dupe: bool,
         flip: bool,
-        glyph_index: u16,
+        glyph_index: GlyphId,
         target_ppem: u16,
         max_bit_depth: BitDepth,
     ) -> Result<Option<BitmapGlyph>, ParseError> {
@@ -717,7 +717,7 @@ impl<T: FontTableProvider> Font<T> {
     fn lookup_svg_glyph(
         &self,
         svg: &tables::Svg,
-        glyph_index: u16,
+        glyph_index: GlyphId,
     ) -> Result<Option<BitmapGlyph>, ParseError> {
         svg.with_table(
             |svg_table: &SvgTable<'_>| match svg_table.lookup_glyph(glyph_index)? {
@@ -777,11 +777,11 @@ impl<T: FontTableProvider> Font<T> {
     ///
     /// Will return `None` if there are errors encountered reading the `hmtx` table or there is
     /// no entry for the glyph index.
-    pub fn horizontal_advance(&mut self, glyph: u16) -> Option<u16> {
+    pub fn horizontal_advance(&mut self, glyph: GlyphId) -> Option<u16> {
         glyph_info::advance(&self.maxp_table, &self.hhea_table, &self.hmtx_table, glyph).ok()
     }
 
-    pub fn vertical_advance(&mut self, glyph: u16) -> Option<u16> {
+    pub fn vertical_advance(&mut self, glyph: GlyphId) -> Option<u16> {
         let provider = &self.font_table_provider;
         let vmtx = self
             .vmtx_table
@@ -927,7 +927,7 @@ impl GlyphCache {
         }
     }
 
-    fn put(&mut self, ch: char, glyph_index: u16, variation_selector: VariationSelector) {
+    fn put(&mut self, ch: char, glyph_index: GlyphId, variation_selector: VariationSelector) {
         if ch == DOTTED_CIRCLE {
             match self.0 {
                 Some(_) => panic!("duplicate entry"),

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -3284,8 +3284,8 @@ pub enum Coverage {
 }
 
 pub struct CoverageRangeRecord {
-    start_glyph: u16,
-    end_glyph: u16,
+    start_glyph: GlyphId,
+    end_glyph: GlyphId,
     start_coverage_index: u16,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -164,6 +164,8 @@ pub use tinyvec;
 pub const DOTTED_CIRCLE: char = '◌';
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");
 
+pub type GlyphId = u16;
+
 #[macro_export]
 macro_rules! read_table {
     ($source:expr, $tag:path, $t:ty, $index:expr) => {


### PR DESCRIPTION
Resolves #117 

Moved GlyphId alias to lib.rs, and imported it in the places already using it.

We could open another issue to begin migrating to GlyphId for code that currently uses u16 for glyph id's, or just start here.