### PR TITLE
Gsub buffer limit

### DIFF
--- a/src/gsub.rs
+++ b/src/gsub.rs
@@ -27,6 +27,7 @@ use crate::unicode::VariationSelector;
 use crate::{tag, GlyphId};
 
 const SUBST_RECURSION_LIMIT: usize = 2;
+const MAX_GLYPHS: usize = 10_000;
 
 #[derive(Copy, Clone, Eq, PartialEq, Debug)]
 pub struct FeatureInfo {
@@ -462,6 +463,10 @@ fn multiplesubst<T: GlyphData>(
 ) -> Result<Option<usize>, ParseError> {
     match multiplesubst_would_apply(subtables, i, glyphs)? {
         Some(sequence_table) => {
+            if sequence_table.substitute_glyphs.len() + glyphs.len() >= MAX_GLYPHS {
+                return Err(ParseError::LimitExceeded);
+            }
+
             if !sequence_table.substitute_glyphs.is_empty() {
                 let first_glyph_index = sequence_table.substitute_glyphs[0];
                 glyphs[i].glyph_index = first_glyph_index;

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -1448,7 +1448,7 @@ pub struct MultipleSubst {
 }
 
 pub struct SequenceTable {
-    pub substitute_glyphs: Vec<u16>,
+    pub substitute_glyphs: Vec<GlyphId>,
 }
 
 impl ReadBinaryDep for MultipleSubst {


### PR DESCRIPTION
Adds buffer limit from #48 

This PR adds the buffer limit to 10000 during multiplesubst in the GSUB table as asked for in #48.

I'll add a test once I know I applied the correct fix.
If this wasn't the expected fix, please tell me and I will gladly update it.