### PR TITLE
Fix #126 `DynamicFontTableProvider` not being `Send + Sync`

### DIFF
--- a/src/font_data.rs
+++ b/src/font_data.rs
@@ -21,7 +21,7 @@ pub enum FontData<'a> {
 /// Generic implementation of the `FontTableProvider` trait
 pub struct DynamicFontTableProvider<'a> {
     sfnt_version: u32,
-    provider: Box<dyn FontTableProvider + 'a>,
+    provider: Box<dyn FontTableProvider + Send + Sync + 'a>,
 }
 
 impl ReadBinary for FontData<'_> {


### PR DESCRIPTION
Added constraint `Send + Sync` on the `Box<dyn ...>` inside `font_data::DynamicFontTableProvider` in order to make the type `Send + Sync`.

All tests pass.

Closes #126 

