### PR TITLE
Reduce direct dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,6 @@ categories = ["text-processing"]
 enumflags2 = "0.7"
 bitreader = "0.3.6"
 brotli-decompressor = "5.0"
-crc32fast = "1.3.2"
 encoding_rs = "0.8.32"
 flate2 = { version = "1.0", default-features = false, optional = true }
 glyph-names = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,6 @@ categories = ["text-processing"]
 
 [dependencies]
 enumflags2 = "0.7"
-bitreader = "0.3.6"
 brotli-decompressor = "5.0"
 encoding_rs = "0.8.32"
 flate2 = { version = "1.0", default-features = false, optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,6 @@ encoding_rs = "0.8.32"
 flate2 = { version = "1.0", default-features = false, optional = true }
 glyph-names = "0.2"
 log = "0.4"
-num-traits = "0.2"
 ouroboros = "0.18"
 pathfinder_geometry = { version = "0.5.1" }
 rustc-hash = "2.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,6 @@ flate2 = { version = "1.0", default-features = false, optional = true }
 glyph-names = "0.2"
 log = "0.4"
 ouroboros = "0.18"
-pathfinder_geometry = { version = "0.5.1" }
 rustc-hash = "2.0.0"
 tinyvec = { version = "1", features = ["std", "rustc_1_57"] }
 ucd-trie = "0.1.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,6 @@ flate2 = { version = "1.0", default-features = false, optional = true }
 glyph-names = "0.2"
 itertools = "0.14"
 lazy_static = "1.4.0"
-libc = "0.2"
 log = "0.4"
 num-traits = "0.2"
 ouroboros = "0.18"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,6 @@ brotli-decompressor = "5.0"
 encoding_rs = "0.8.32"
 flate2 = { version = "1.0", default-features = false, optional = true }
 glyph-names = "0.2"
-itertools = "0.14"
 log = "0.4"
 num-traits = "0.2"
 ouroboros = "0.18"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,6 @@ categories = ["text-processing"]
 enumflags2 = "0.7"
 bitreader = "0.3.6"
 brotli-decompressor = "5.0"
-byteorder = "1.4"
 crc32fast = "1.3.2"
 encoding_rs = "0.8.32"
 flate2 = { version = "1.0", default-features = false, optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,6 @@ encoding_rs = "0.8.32"
 flate2 = { version = "1.0", default-features = false, optional = true }
 glyph-names = "0.2"
 itertools = "0.14"
-lazy_static = "1.4.0"
 log = "0.4"
 num-traits = "0.2"
 ouroboros = "0.18"

--- a/src/bitmap.rs
+++ b/src/bitmap.rs
@@ -5,8 +5,6 @@
 pub mod cbdt;
 pub mod sbix;
 
-use num_traits as num;
-
 use crate::error::ParseError;
 
 /// Bit depth of bitmap data.
@@ -164,17 +162,17 @@ impl EmbeddedMetrics {
 
 /// Returns true if `value` is closer to zero than `current_best`, favouring positive values even
 /// if they're further away from zero.
-fn bigger_or_closer_to_zero<V>(value: V, current_best: V) -> bool
-where
-    V: PartialOrd + num::Signed + num::Zero,
-{
-    if value == V::zero() {
+///
+/// Both call sites pass an `i16` or `i32` "ppem difference"; widening to `i32` keeps a
+/// single concrete impl with no runtime cost.
+fn bigger_or_closer_to_zero(value: i32, current_best: i32) -> bool {
+    if value == 0 {
         return true;
-    } else if current_best == V::zero() {
+    } else if current_best == 0 {
         return false;
     }
 
-    match (current_best.is_positive(), value.is_positive()) {
+    match (current_best > 0, value > 0) {
         (true, true) if value < current_best => true,
         (true, false) => false,
         (false, true) => true,

--- a/src/bitmap/cbdt.rs
+++ b/src/bitmap/cbdt.rs
@@ -1539,7 +1539,6 @@ fn bgra_to_rgba(bit_depth: BitDepth, mut data: Vec<u8>) -> Result<Vec<u8>, Parse
 
 #[cfg(test)]
 mod tests {
-    use itertools::Itertools;
     use std::borrow::Borrow;
     use std::path::Path;
 

--- a/src/bitmap/cbdt.rs
+++ b/src/bitmap/cbdt.rs
@@ -623,7 +623,10 @@ impl<'a> CBLCTable<'a> {
                     best = Some((difference, bitmap_size, index))
                 }
                 Some((current_best_difference, _, _))
-                    if super::bigger_or_closer_to_zero(difference, current_best_difference) =>
+                    if super::bigger_or_closer_to_zero(
+                        i32::from(difference),
+                        i32::from(current_best_difference),
+                    ) =>
                 {
                     best = Some((difference, bitmap_size, index))
                 }

--- a/src/bitmap/cbdt.rs
+++ b/src/bitmap/cbdt.rs
@@ -1561,7 +1561,7 @@ mod tests {
             .index_sub_table_records
             .iter()
             .map(|rec| rec.first_glyph_index..=rec.last_glyph_index)
-            .collect_vec();
+            .collect::<Vec<_>>();
         assert_eq!(ranges, &[4..=17, 19..=1316, 1354..=3112]);
     }
 

--- a/src/bitmap/cbdt.rs
+++ b/src/bitmap/cbdt.rs
@@ -4,8 +4,6 @@
 
 use std::fmt;
 
-use bitreader::{BitReader, BitReaderError};
-
 use super::BitDepth;
 use crate::binary::read::{
     ReadArray, ReadBinary, ReadBinaryDep, ReadCtxt, ReadFixedSizeDep, ReadFrom, ReadScope,
@@ -1086,7 +1084,6 @@ impl<'a> TryFrom<(&BitmapInfo, GlyphBitmapData<'a>, u16)> for BitmapGlyph {
                     small_metrics.height,
                     data,
                 )
-                .map_err(parse_error_from_bitreader_error)
                 .and_then(|data| bgra_to_rgba(info.bit_depth, data))?;
                 BitmapGlyph {
                     bitmap: Bitmap::Embedded(EmbeddedBitmap {
@@ -1111,7 +1108,6 @@ impl<'a> TryFrom<(&BitmapInfo, GlyphBitmapData<'a>, u16)> for BitmapGlyph {
                     big_metrics.height,
                     data,
                 )
-                .map_err(parse_error_from_bitreader_error)
                 .and_then(|data| bgra_to_rgba(info.bit_depth, data))?;
                 BitmapGlyph {
                     bitmap: Bitmap::Embedded(EmbeddedBitmap {
@@ -1154,7 +1150,6 @@ impl<'a> TryFrom<(&BitmapInfo, GlyphBitmapData<'a>, u16)> for BitmapGlyph {
                     big_metrics.height,
                     data,
                 )
-                .map_err(parse_error_from_bitreader_error)
                 .and_then(|data| bgra_to_rgba(info.bit_depth, data))?;
                 BitmapGlyph {
                     bitmap: Bitmap::Embedded(EmbeddedBitmap {
@@ -1458,7 +1453,7 @@ fn unpack_bit_aligned_data(
     width: u8,
     height: u8,
     data: &[u8],
-) -> Result<Vec<u8>, BitReaderError> {
+) -> Result<Vec<u8>, ParseError> {
     let bits_per_row = bit_depth as usize * usize::from(width);
     let whole_bytes_per_row = bits_per_row >> 3;
     let remaining_bits = (bits_per_row & 7) as u8;
@@ -1483,14 +1478,49 @@ fn unpack_bit_aligned_data(
     Ok(image_data)
 }
 
-fn parse_error_from_bitreader_error(err: BitReaderError) -> ParseError {
-    match err {
-        BitReaderError::NotEnoughData { .. } => ParseError::BadEof,
-        BitReaderError::TooManyBitsForType { .. } => {
-            // This should only happen as a result of programmer error as we only call bitreader
-            // with values <= 8.
-            unreachable!("{}", err)
+/// MSB-first bit reader for CBDT/EBDT bit-aligned glyph data.
+///
+/// Only the 1..=8 bit case is exercised by callers in this file, which
+/// matches the CBDT/EBDT-spec-defined range for `BitDepth` values.
+struct BitReader<'a> {
+    data: &'a [u8],
+    bit_pos: usize,
+}
+
+impl<'a> BitReader<'a> {
+    fn new(data: &'a [u8]) -> Self {
+        BitReader { data, bit_pos: 0 }
+    }
+
+    /// Read `bits` bits (1..=8) as a big-endian-packed `u8`.
+    ///
+    /// Returns `ParseError::BadEof` if there aren't enough bits remaining.
+    fn read_u8(&mut self, bits: u8) -> Result<u8, ParseError> {
+        debug_assert!(bits <= 8);
+        if bits == 0 {
+            return Ok(0);
         }
+        let total_bits = self.data.len() * 8;
+        if self.bit_pos + usize::from(bits) > total_bits {
+            return Err(ParseError::BadEof);
+        }
+
+        let byte_index = self.bit_pos >> 3;
+        let bit_offset = (self.bit_pos & 7) as u32;
+        // Pull up to two bytes into a 16-bit window so we can shift out the
+        // requested run regardless of byte alignment.
+        let hi = u16::from(self.data[byte_index]);
+        let lo = if byte_index + 1 < self.data.len() {
+            u16::from(self.data[byte_index + 1])
+        } else {
+            0
+        };
+        let window = (hi << 8) | lo;
+        let shift = 16 - bit_offset - u32::from(bits);
+        let mask = (1u16 << bits) - 1;
+        let value = ((window >> shift) & mask) as u8;
+        self.bit_pos += usize::from(bits);
+        Ok(value)
     }
 }
 

--- a/src/cff.rs
+++ b/src/cff.rs
@@ -13,7 +13,6 @@ use std::iter;
 use std::marker::PhantomData;
 use std::sync::OnceLock;
 
-use num_traits as num;
 use tinyvec::{array_vec, tiny_vec, TinyVec};
 
 use crate::binary::read::{
@@ -1086,7 +1085,7 @@ impl WriteBinary for Range<SID, u16> {
 
 impl<F, N> Range<F, N>
 where
-    N: num::Unsigned + Copy,
+    N: Copy,
     usize: From<N>,
 {
     pub fn len(&self) -> usize {
@@ -1304,8 +1303,8 @@ impl<'a> CustomCharset<'a> {
         sid: SID,
     ) -> Option<u16>
     where
-        F: num::Unsigned + Copy,
-        N: num::Unsigned + Copy,
+        F: Copy,
+        N: Copy,
         u32: From<N> + From<F>,
         u16: From<N> + From<F>,
         Range<F, N>: ReadFrom,
@@ -1329,8 +1328,8 @@ impl<'a> CustomCharset<'a> {
         glyph_id: u16,
     ) -> Option<u16>
     where
-        F: num::Unsigned + Copy,
-        N: num::Unsigned + Copy,
+        F: Copy,
+        N: Copy,
         usize: From<N> + From<F>,
         Range<F, N>: ReadFrom,
         <Range<F, N> as ReadUnchecked>::HostType: Copy,
@@ -2134,7 +2133,7 @@ fn read_range_array<'a, F, N>(
 where
     Range<F, N>: ReadFrom,
     usize: From<N>,
-    N: num::Unsigned + Copy,
+    N: Copy,
 {
     let mut peek = ctxt.scope().ctxt();
     let mut range_count = 0;

--- a/src/cff.rs
+++ b/src/cff.rs
@@ -11,9 +11,9 @@ mod subset;
 use std::io::Write;
 use std::iter;
 use std::marker::PhantomData;
+use std::sync::OnceLock;
 
 use itertools::Itertools;
-use lazy_static::lazy_static;
 use num_traits as num;
 use tinyvec::{array_vec, tiny_vec, TinyVec};
 
@@ -43,19 +43,6 @@ const OFFSET_ZERO: [Operand; 1] = [Operand::Offset(0)];
 const DEFAULT_UNDERLINE_POSITION: [Operand; 1] = [Operand::Integer(-100)];
 const DEFAULT_UNDERLINE_THICKNESS: [Operand; 1] = [Operand::Integer(50)];
 const DEFAULT_CHARSTRING_TYPE: [Operand; 1] = [Operand::Integer(2)];
-lazy_static! {
-    static ref DEFAULT_FONT_MATRIX: [Operand; 6] = {
-        let real_0_001 = Operand::Real(Real(tiny_vec![0x0a, 0x00, 0x1f])); // 0.001
-        [
-            real_0_001.clone(),
-            Operand::Integer(0),
-            Operand::Integer(0),
-            real_0_001,
-            Operand::Integer(0),
-            Operand::Integer(0),
-        ]
-    };
-}
 const DEFAULT_BBOX: [Operand; 4] = [
     Operand::Integer(0),
     Operand::Integer(0),
@@ -65,11 +52,34 @@ const DEFAULT_BBOX: [Operand; 4] = [
 const DEFAULT_CID_COUNT: [Operand; 1] = [Operand::Integer(8720)];
 const DEFAULT_BLUE_SHIFT: [Operand; 1] = [Operand::Integer(7)];
 const DEFAULT_BLUE_FUZZ: [Operand; 1] = [Operand::Integer(1)];
-lazy_static! {
-    static ref DEFAULT_BLUE_SCALE: [Operand; 1] =
-        [Operand::Real(Real(tiny_vec![0x0a, 0x03, 0x96, 0x25, 0xff]))]; // 0.039625
-    static ref DEFAULT_EXPANSION_FACTOR: [Operand; 1] =
-        [Operand::Real(Real(tiny_vec![0x0a, 0x06, 0xff]))]; // 0.06
+
+// Operands containing `Real` values can't be const because `Real` wraps a
+// `TinyVec`, whose construction isn't const. They are computed once on first
+// access via `OnceLock` and reused thereafter.
+
+pub(crate) fn default_font_matrix() -> &'static [Operand; 6] {
+    static V: OnceLock<[Operand; 6]> = OnceLock::new();
+    V.get_or_init(|| {
+        let real_0_001 = Operand::Real(Real(tiny_vec![0x0a, 0x00, 0x1f])); // 0.001
+        [
+            real_0_001.clone(),
+            Operand::Integer(0),
+            Operand::Integer(0),
+            real_0_001,
+            Operand::Integer(0),
+            Operand::Integer(0),
+        ]
+    })
+}
+
+pub(crate) fn default_blue_scale() -> &'static [Operand; 1] {
+    static V: OnceLock<[Operand; 1]> = OnceLock::new();
+    V.get_or_init(|| [Operand::Real(Real(tiny_vec![0x0a, 0x03, 0x96, 0x25, 0xff]))]) // 0.039625
+}
+
+pub(crate) fn default_expansion_factor() -> &'static [Operand; 1] {
+    static V: OnceLock<[Operand; 1]> = OnceLock::new();
+    V.get_or_init(|| [Operand::Real(Real(tiny_vec![0x0a, 0x06, 0xff]))]) // 0.06
 }
 
 const ISO_ADOBE_LAST_SID: u16 = 228;
@@ -1655,7 +1665,7 @@ impl DictDefault for TopDictDefault {
             Operator::UnderlineThickness => Some(&DEFAULT_UNDERLINE_THICKNESS),
             Operator::PaintType => Some(&OPERAND_ZERO),
             Operator::CharstringType => Some(&DEFAULT_CHARSTRING_TYPE),
-            Operator::FontMatrix => Some(DEFAULT_FONT_MATRIX.as_ref()),
+            Operator::FontMatrix => Some(default_font_matrix().as_ref()),
             Operator::FontBBox => Some(&DEFAULT_BBOX),
             Operator::StrokeWidth => Some(&OPERAND_ZERO),
             Operator::Charset => Some(&OFFSET_ZERO),
@@ -1678,12 +1688,12 @@ impl DictDefault for FontDictDefault {
 impl DictDefault for PrivateDictDefault {
     fn default(op: Operator) -> Option<&'static [Operand]> {
         match op {
-            Operator::BlueScale => Some(DEFAULT_BLUE_SCALE.as_ref()),
+            Operator::BlueScale => Some(default_blue_scale().as_ref()),
             Operator::BlueShift => Some(&DEFAULT_BLUE_SHIFT),
             Operator::BlueFuzz => Some(&DEFAULT_BLUE_FUZZ),
             Operator::ForceBold => Some(&OPERAND_ZERO),
             Operator::LanguageGroup => Some(&OPERAND_ZERO),
-            Operator::ExpansionFactor => Some(DEFAULT_EXPANSION_FACTOR.as_ref()),
+            Operator::ExpansionFactor => Some(default_expansion_factor().as_ref()),
             Operator::InitialRandomSeed => Some(&OPERAND_ZERO),
             Operator::StrokeWidth => Some(&OPERAND_ZERO),
             Operator::DefaultWidthX => Some(&OPERAND_ZERO),

--- a/src/cff.rs
+++ b/src/cff.rs
@@ -12,7 +12,6 @@ use std::io::Write;
 use std::iter;
 use std::marker::PhantomData;
 
-use byteorder::{BigEndian, ByteOrder};
 use itertools::Itertools;
 use lazy_static::lazy_static;
 use num_traits as num;
@@ -2109,9 +2108,9 @@ fn lookup_offset_index(off_size: u8, offset_array: &[u8], index: usize) -> usize
     let buf = &offset_array[index * usize::from(off_size)..];
     match off_size {
         1 => buf[0] as usize,
-        2 => BigEndian::read_u16(buf) as usize,
-        3 => BigEndian::read_u24(buf) as usize,
-        4 => BigEndian::read_u32(buf) as usize,
+        2 => u16::from_be_bytes([buf[0], buf[1]]) as usize,
+        3 => u32::from_be_bytes([0, buf[0], buf[1], buf[2]]) as usize,
+        4 => u32::from_be_bytes([buf[0], buf[1], buf[2], buf[3]]) as usize,
         _ => panic!("unexpected off_size"),
     }
 }

--- a/src/cff.rs
+++ b/src/cff.rs
@@ -551,7 +551,7 @@ impl<'a> WriteBinary<&Self> for CFF<'a> {
     fn write<C: WriteContext>(ctxt: &mut C, cff: &CFF<'a>) -> Result<(), WriteError> {
         Header::write(ctxt, &cff.header)?;
         MaybeOwnedIndex::write16(ctxt, &cff.name_index)?;
-        let top_dicts = cff.fonts.iter().map(|font| &font.top_dict).collect_vec();
+        let top_dicts = cff.fonts.iter().map(|font| &font.top_dict).collect::<Vec<_>>();
         let top_dict_index_length =
             Index::calculate_size::<TopDict, _>(top_dicts.as_slice(), DictDelta::new())?;
         let top_dict_index_placeholder = ctxt.reserve::<IndexU16, _>(top_dict_index_length)?;
@@ -3606,7 +3606,7 @@ mod tests {
         let format0_encoding = ctxt.read::<CustomEncoding<'_>>().unwrap();
         match format0_encoding {
             CustomEncoding::Format0 { codes } => {
-                assert_eq!(codes.iter().collect_vec(), vec![4, 5, 6])
+                assert_eq!(codes.iter().collect::<Vec<_>>(), vec![4, 5, 6])
             }
             _ => panic!("expected CustomEncoding::Format0 got something else"),
         }
@@ -3619,7 +3619,7 @@ mod tests {
         let format1_encoding = ctxt.read::<CustomEncoding<'_>>().unwrap();
         match format1_encoding {
             CustomEncoding::Format1 { ranges } => assert_eq!(
-                ranges.iter().collect_vec(),
+                ranges.iter().collect::<Vec<_>>(),
                 vec![
                     Range {
                         first: 4,
@@ -3643,7 +3643,7 @@ mod tests {
         let format0_charset = ctxt.read_dep::<CustomCharset<'_>>(n_glyphs).unwrap();
         match format0_charset {
             CustomCharset::Format0 { glyphs } => {
-                assert_eq!(glyphs.iter().collect_vec(), vec![0xAABB])
+                assert_eq!(glyphs.iter().collect::<Vec<_>>(), vec![0xAABB])
             }
             _ => panic!("expected CustomCharset::Format0 got something else"),
         }
@@ -3657,7 +3657,7 @@ mod tests {
         let format1_charset = ctxt.read_dep::<CustomCharset<'_>>(n_glyphs).unwrap();
         match format1_charset {
             CustomCharset::Format1 { ranges } => assert_eq!(
-                ranges.iter().collect_vec(),
+                ranges.iter().collect::<Vec<_>>(),
                 vec![Range {
                     first: 1,
                     n_left: 3
@@ -3675,7 +3675,7 @@ mod tests {
         let format2_charset = ctxt.read_dep::<CustomCharset<'_>>(n_glyphs).unwrap();
         match format2_charset {
             CustomCharset::Format2 { ranges } => assert_eq!(
-                ranges.iter().collect_vec(),
+                ranges.iter().collect::<Vec<_>>(),
                 vec![Range {
                     first: 1,
                     n_left: 3
@@ -3893,7 +3893,7 @@ mod tests {
             Range { first: 2972, n_left: 2, },
         ]);
         let charset = CustomCharset::Format2 { ranges };
-        let actual = charset.iter().collect_vec();
+        let actual = charset.iter().collect::<Vec<_>>();
         let expected = vec![0, 111, 112, 113, 114, 115, 1, 2, 3, 4, 2972, 2973, 2974];
 
         assert_eq!(actual, expected);

--- a/src/cff.rs
+++ b/src/cff.rs
@@ -13,7 +13,6 @@ use std::iter;
 use std::marker::PhantomData;
 use std::sync::OnceLock;
 
-use itertools::Itertools;
 use num_traits as num;
 use tinyvec::{array_vec, tiny_vec, TinyVec};
 
@@ -1457,14 +1456,17 @@ impl FDSelect<'_> {
                 glyph_font_dict_indices,
             } => glyph_font_dict_indices.get_item(index),
             FDSelect::Format3 { ranges, sentinel } => {
-                #[rustfmt::skip]
-                let range_windows = ranges
+                let mut iter = ranges
                     .iter()
                     .map(|Range { first, n_left }| (first, Some(n_left)))
                     .chain(iter::once((*sentinel, None)))
-                    .tuple_windows();
+                    .peekable();
 
-                for ((first, fd_index), (last, _)) in range_windows {
+                while let Some((first, fd_index)) = iter.next() {
+                    let &(last, _) = match iter.peek() {
+                        Some(next) => next,
+                        None => break,
+                    };
                     if glyph_id >= first && glyph_id < last {
                         return fd_index;
                     }

--- a/src/cff/cff2.rs
+++ b/src/cff/cff2.rs
@@ -9,8 +9,9 @@ use std::fmt::Debug;
 use super::{
     owned, read_local_subr_index, CFFError, CFFFont, CFFVariant, CIDData, Charset, CustomCharset,
     Dict, DictDefault, DictDelta, Encoding, FDSelect, Index, IndexU32, MaybeOwnedIndex, Operand,
-    Operator, SubsetCFF, Type1Data, CFF, DEFAULT_BLUE_FUZZ, DEFAULT_BLUE_SCALE, DEFAULT_BLUE_SHIFT,
-    DEFAULT_EXPANSION_FACTOR, DEFAULT_FONT_MATRIX, ISO_ADOBE_LAST_SID, OFFSET_ZERO, OPERAND_ZERO,
+    default_blue_scale, default_expansion_factor, default_font_matrix, Operator, SubsetCFF,
+    Type1Data, CFF, DEFAULT_BLUE_FUZZ, DEFAULT_BLUE_SHIFT, ISO_ADOBE_LAST_SID, OFFSET_ZERO,
+    OPERAND_ZERO,
     STANDARD_STRINGS,
 };
 use crate::binary::read::{ReadArrayCow, ReadBinary, ReadCtxt, ReadScope};
@@ -1348,7 +1349,7 @@ impl<'a> WriteBinary<&Index<'a>> for IndexU32 {
 impl DictDefault for TopDictDefault {
     fn default(op: Operator) -> Option<&'static [Operand]> {
         match op {
-            Operator::FontMatrix => Some(DEFAULT_FONT_MATRIX.as_ref()),
+            Operator::FontMatrix => Some(default_font_matrix().as_ref()),
             _ => None,
         }
     }
@@ -1363,11 +1364,11 @@ impl DictDefault for FontDictDefault {
 impl DictDefault for PrivateDictDefault {
     fn default(op: Operator) -> Option<&'static [Operand]> {
         match op {
-            Operator::BlueScale => Some(DEFAULT_BLUE_SCALE.as_ref()),
+            Operator::BlueScale => Some(default_blue_scale().as_ref()),
             Operator::BlueShift => Some(&DEFAULT_BLUE_SHIFT),
             Operator::BlueFuzz => Some(&DEFAULT_BLUE_FUZZ),
             Operator::LanguageGroup => Some(&OPERAND_ZERO),
-            Operator::ExpansionFactor => Some(DEFAULT_EXPANSION_FACTOR.as_ref()),
+            Operator::ExpansionFactor => Some(default_expansion_factor().as_ref()),
             Operator::VSIndex => Some(&OPERAND_ZERO),
             _ => None,
         }

--- a/src/cff/outline.rs
+++ b/src/cff/outline.rs
@@ -3,14 +3,12 @@
 // Portions of this file derived from ttf-parser, licenced under Apache-2.0.
 // https://github.com/RazrFalcon/ttf-parser/tree/439aaaebd50eb8aed66302e3c1b51fae047f85b2
 
-use pathfinder_geometry::line_segment::LineSegment2F;
-use pathfinder_geometry::vector::vec2f;
-
 use cff2::CFF2;
 use charstring::CharStringParser;
 
 use crate::cff;
 use crate::error::ParseError;
+use crate::geom::{vec2f, LineSegment2F};
 use crate::outline::{BoundingBoxSink, OutlineBuilder, OutlineSink};
 use crate::tables::glyf::BoundingBox;
 use crate::tables::variable_fonts::OwnedTuple;
@@ -241,8 +239,7 @@ impl<B: OutlineSink> CharStringVisitor<f32, CFFError> for CharStringParser<'_, B
 #[cfg(test)]
 mod tests {
     use crate::binary::read::ReadScope;
-    use pathfinder_geometry::rect::RectI;
-    use pathfinder_geometry::vector::{vec2i, Vector2F, Vector2I};
+    use crate::geom::{vec2i, RectI, Vector2F, Vector2I};
     use std::fmt::Write;
     use std::marker::PhantomData;
 

--- a/src/crc32.rs
+++ b/src/crc32.rs
@@ -1,0 +1,45 @@
+//! Minimal CRC-32 (IEEE 802.3 / gzip / PNG polynomial).
+//!
+//! Used by the variable-font PostScript-name generator to produce the
+//! "last resort" hashed suffix described in the OpenType specification's
+//! *Generating PostScript names for OpenType Font Variations* section,
+//! which calls for the IEEE 802.3 CRC-32. This is not on a hot path —
+//! it only runs when a generated PostScript name exceeds 63 characters —
+//! so a simple bitwise implementation is preferred over pulling in a
+//! dedicated CRC-32 crate.
+
+const POLY: u32 = 0xEDB88320;
+
+pub fn hash(bytes: &[u8]) -> u32 {
+    let mut crc: u32 = !0;
+    for &byte in bytes {
+        crc ^= u32::from(byte);
+        for _ in 0..8 {
+            let mask = (crc & 1).wrapping_neg();
+            crc = (crc >> 1) ^ (POLY & mask);
+        }
+    }
+    !crc
+}
+
+#[cfg(test)]
+mod tests {
+    use super::hash;
+
+    // Reference values from the standard IEEE 802.3 CRC-32 (gzip / PNG).
+    #[test]
+    fn empty() {
+        assert_eq!(hash(b""), 0);
+    }
+
+    #[test]
+    fn ascii() {
+        // "123456789" has the well-known check value 0xCBF43926.
+        assert_eq!(hash(b"123456789"), 0xCBF43926);
+    }
+
+    #[test]
+    fn short() {
+        assert_eq!(hash(b"a"), 0xE8B7BE43);
+    }
+}

--- a/src/font.rs
+++ b/src/font.rs
@@ -4,10 +4,9 @@ use std::borrow::Cow;
 use std::convert::{self};
 use std::sync::Arc;
 
-use pathfinder_geometry::line_segment::LineSegment2F;
-use pathfinder_geometry::rect::RectF;
-use pathfinder_geometry::vector::Vector2F;
 use tinyvec::tiny_vec;
+
+use crate::geom::{LineSegment2F, RectF, Vector2F};
 
 use crate::big5::unicode_to_big5;
 use crate::binary::read::ReadScope;

--- a/src/geom.rs
+++ b/src/geom.rs
@@ -28,7 +28,7 @@
 //!   the four corners and returns the axis-aligned bounding box of the
 //!   result.
 
-use std::ops::{Add, Div, Mul, Sub};
+use std::ops::{Add, AddAssign, Div, Mul, Sub};
 
 // ---------------------------------------------------------------------------
 // Vector2F
@@ -86,6 +86,30 @@ impl Vector2F {
     pub fn clamp(self, min: Self, max: Self) -> Self {
         self.max(min).min(max)
     }
+
+    /// Component-wise rounding to the nearest integer (ties-to-even matches `f32::round`).
+    #[inline]
+    pub fn round(self) -> Self {
+        Vector2F {
+            x: self.x.round(),
+            y: self.y.round(),
+        }
+    }
+
+    /// Component-wise cast to integer, truncating toward zero (matches `f32 as i32`).
+    #[inline]
+    pub fn to_i32(self) -> Vector2I {
+        Vector2I {
+            x: self.x as i32,
+            y: self.y as i32,
+        }
+    }
+
+    /// Linear interpolation between `self` and `other`: `self + (other - self) * t`.
+    #[inline]
+    pub fn lerp(self, other: Self, t: f32) -> Self {
+        self + (other - self) * t
+    }
 }
 
 #[inline]
@@ -133,6 +157,14 @@ impl Div for Vector2F {
     }
 }
 
+impl AddAssign for Vector2F {
+    #[inline]
+    fn add_assign(&mut self, rhs: Self) {
+        self.x += rhs.x;
+        self.y += rhs.y;
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Vector2I
 // ---------------------------------------------------------------------------
@@ -162,6 +194,24 @@ impl Vector2I {
     #[inline]
     pub fn y(self) -> i32 {
         self.y
+    }
+
+    /// Component-wise minimum.
+    #[inline]
+    pub fn min(self, other: Self) -> Self {
+        Vector2I {
+            x: self.x.min(other.x),
+            y: self.y.min(other.y),
+        }
+    }
+
+    /// Component-wise maximum.
+    #[inline]
+    pub fn max(self, other: Self) -> Self {
+        Vector2I {
+            x: self.x.max(other.x),
+            y: self.y.max(other.y),
+        }
     }
 }
 
@@ -248,6 +298,36 @@ impl RectF {
             self.lower_right.max(other.lower_right),
         )
     }
+
+    /// Cast each corner component to an `i32`, truncating toward zero.
+    #[inline]
+    pub fn to_i32(self) -> RectI {
+        RectI::from_points(self.origin.to_i32(), self.lower_right.to_i32())
+    }
+
+    /// X coordinate of the origin (alias of `min_x` matching pathfinder's API).
+    #[inline]
+    pub fn origin_x(self) -> f32 {
+        self.origin.x
+    }
+
+    /// Y coordinate of the origin (alias of `min_y`).
+    #[inline]
+    pub fn origin_y(self) -> f32 {
+        self.origin.y
+    }
+
+    /// `max_x - min_x`. Negative values are possible for non-normalised rects.
+    #[inline]
+    pub fn width(self) -> f32 {
+        self.lower_right.x - self.origin.x
+    }
+
+    /// `max_y - min_y`. Negative values are possible for non-normalised rects.
+    #[inline]
+    pub fn height(self) -> f32 {
+        self.lower_right.y - self.origin.y
+    }
 }
 
 impl Add<Vector2F> for RectF {
@@ -298,6 +378,18 @@ impl RectI {
     pub fn max_y(self) -> i32 {
         self.lower_right.y
     }
+
+    /// The origin (top-left) corner of the rectangle.
+    #[inline]
+    pub fn origin(self) -> Vector2I {
+        self.origin
+    }
+
+    /// The lower-right corner of the rectangle.
+    #[inline]
+    pub fn lower_right(self) -> Vector2I {
+        self.lower_right
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -324,6 +416,26 @@ impl LineSegment2F {
     #[inline]
     pub fn to(self) -> Vector2F {
         self.to
+    }
+
+    #[inline]
+    pub fn from_x(self) -> f32 {
+        self.from.x
+    }
+
+    #[inline]
+    pub fn from_y(self) -> f32 {
+        self.from.y
+    }
+
+    #[inline]
+    pub fn to_x(self) -> f32 {
+        self.to.x
+    }
+
+    #[inline]
+    pub fn to_y(self) -> f32 {
+        self.to.y
     }
 }
 

--- a/src/geom.rs
+++ b/src/geom.rs
@@ -1,0 +1,530 @@
+//! 2D geometry primitives used by the outline / variations / COLR code paths.
+//!
+//! Replaces the pathfinder_geometry dependency with a small native module
+//! covering only the types, operators, and methods that allsorts actually
+//! uses. Behaviour is intended to match pathfinder_geometry exactly for the
+//! API surface listed below; in particular, constructors that take two
+//! corners (`RectF::from_points`, `RectI::from_points`) do **not** normalise
+//! the inputs — callers that need a min/max bounding box must pre-order the
+//! corners (which mirrors pathfinder's contract).
+//!
+//! API surface:
+//!
+//! * [`Vector2F`], [`Vector2I`] — 2D float / int vectors. Constructors
+//!   `new`, `splat`, `zero`, plus `vec2f` / `vec2i` shorthand. Arithmetic
+//!   is component-wise except `Mul<f32>` which is scalar.
+//! * [`RectF`], [`RectI`] — axis-aligned rectangles built from two corner
+//!   points. `from_points`, `min_x` / `min_y` / `max_x` / `max_y`,
+//!   `contains_point`, `round_out` (RectF only), `union_point` /
+//!   `union_rect` (RectF only), and `RectF + Vector2F` translation.
+//! * [`LineSegment2F`] — pair of points exposed via `from()` / `to()`.
+//! * [`Matrix2x2F`] — row-major 2×2 matrix with `from_scale` and
+//!   `row_major` constructors.
+//! * [`Transform2F`] — affine 2D transform = `Matrix2x2F` + translation
+//!   `Vector2F`. Constructable as `Transform2F { matrix, vector }` or via
+//!   `row_major(m11, m12, m21, m22, m31, m32)`. Applies as
+//!   `(m11*x + m12*y + m31, m21*x + m22*y + m32)`. Multiplication with
+//!   `Vector2F` transforms a point; multiplication with `RectF` transforms
+//!   the four corners and returns the axis-aligned bounding box of the
+//!   result.
+
+use std::ops::{Add, Div, Mul, Sub};
+
+// ---------------------------------------------------------------------------
+// Vector2F
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Default, Copy, Clone, PartialEq)]
+pub struct Vector2F {
+    x: f32,
+    y: f32,
+}
+
+impl Vector2F {
+    #[inline]
+    pub const fn new(x: f32, y: f32) -> Self {
+        Vector2F { x, y }
+    }
+
+    #[inline]
+    pub const fn splat(s: f32) -> Self {
+        Vector2F { x: s, y: s }
+    }
+
+    #[inline]
+    pub const fn zero() -> Self {
+        Vector2F { x: 0.0, y: 0.0 }
+    }
+
+    #[inline]
+    pub fn x(self) -> f32 {
+        self.x
+    }
+
+    #[inline]
+    pub fn y(self) -> f32 {
+        self.y
+    }
+
+    #[inline]
+    pub fn min(self, other: Self) -> Self {
+        Vector2F {
+            x: self.x.min(other.x),
+            y: self.y.min(other.y),
+        }
+    }
+
+    #[inline]
+    pub fn max(self, other: Self) -> Self {
+        Vector2F {
+            x: self.x.max(other.x),
+            y: self.y.max(other.y),
+        }
+    }
+
+    #[inline]
+    pub fn clamp(self, min: Self, max: Self) -> Self {
+        self.max(min).min(max)
+    }
+}
+
+#[inline]
+pub fn vec2f(x: f32, y: f32) -> Vector2F {
+    Vector2F::new(x, y)
+}
+
+impl Add for Vector2F {
+    type Output = Vector2F;
+    #[inline]
+    fn add(self, rhs: Self) -> Self {
+        Vector2F::new(self.x + rhs.x, self.y + rhs.y)
+    }
+}
+
+impl Sub for Vector2F {
+    type Output = Vector2F;
+    #[inline]
+    fn sub(self, rhs: Self) -> Self {
+        Vector2F::new(self.x - rhs.x, self.y - rhs.y)
+    }
+}
+
+impl Mul for Vector2F {
+    type Output = Vector2F;
+    #[inline]
+    fn mul(self, rhs: Self) -> Self {
+        Vector2F::new(self.x * rhs.x, self.y * rhs.y)
+    }
+}
+
+impl Mul<f32> for Vector2F {
+    type Output = Vector2F;
+    #[inline]
+    fn mul(self, rhs: f32) -> Self {
+        Vector2F::new(self.x * rhs, self.y * rhs)
+    }
+}
+
+impl Div for Vector2F {
+    type Output = Vector2F;
+    #[inline]
+    fn div(self, rhs: Self) -> Self {
+        Vector2F::new(self.x / rhs.x, self.y / rhs.y)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Vector2I
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Default, Copy, Clone, PartialEq, Eq)]
+pub struct Vector2I {
+    x: i32,
+    y: i32,
+}
+
+impl Vector2I {
+    #[inline]
+    pub const fn new(x: i32, y: i32) -> Self {
+        Vector2I { x, y }
+    }
+
+    #[inline]
+    pub const fn zero() -> Self {
+        Vector2I { x: 0, y: 0 }
+    }
+
+    #[inline]
+    pub fn x(self) -> i32 {
+        self.x
+    }
+
+    #[inline]
+    pub fn y(self) -> i32 {
+        self.y
+    }
+}
+
+#[inline]
+pub fn vec2i(x: i32, y: i32) -> Vector2I {
+    Vector2I::new(x, y)
+}
+
+// ---------------------------------------------------------------------------
+// RectF
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Default, Copy, Clone, PartialEq)]
+pub struct RectF {
+    origin: Vector2F,
+    lower_right: Vector2F,
+}
+
+impl RectF {
+    /// Construct a rectangle from two corner points.
+    ///
+    /// The inputs are stored verbatim — `from_points(a, b)` does not
+    /// normalise. Callers that need a min/max bounding rect must pre-order
+    /// the corners (this matches `pathfinder_geometry::RectF::from_points`).
+    #[inline]
+    pub fn from_points(origin: Vector2F, lower_right: Vector2F) -> Self {
+        RectF {
+            origin,
+            lower_right,
+        }
+    }
+
+    #[inline]
+    pub fn min_x(self) -> f32 {
+        self.origin.x
+    }
+
+    #[inline]
+    pub fn min_y(self) -> f32 {
+        self.origin.y
+    }
+
+    #[inline]
+    pub fn max_x(self) -> f32 {
+        self.lower_right.x
+    }
+
+    #[inline]
+    pub fn max_y(self) -> f32 {
+        self.lower_right.y
+    }
+
+    /// Return whether `point` is inside this rectangle (inclusive on the
+    /// origin edges, exclusive on the far edges — matches pathfinder).
+    #[inline]
+    pub fn contains_point(self, point: Vector2F) -> bool {
+        point.x >= self.origin.x
+            && point.y >= self.origin.y
+            && point.x < self.lower_right.x
+            && point.y < self.lower_right.y
+    }
+
+    /// Round the origin down and the lower-right up to the nearest integer
+    /// coordinates, producing a containing rectangle with integer corners.
+    #[inline]
+    pub fn round_out(self) -> RectF {
+        RectF::from_points(
+            Vector2F::new(self.origin.x.floor(), self.origin.y.floor()),
+            Vector2F::new(self.lower_right.x.ceil(), self.lower_right.y.ceil()),
+        )
+    }
+
+    /// Smallest rectangle containing both `self` and `point`.
+    #[inline]
+    pub fn union_point(self, point: Vector2F) -> RectF {
+        RectF::from_points(self.origin.min(point), self.lower_right.max(point))
+    }
+
+    /// Smallest rectangle containing both `self` and `other`.
+    #[inline]
+    pub fn union_rect(self, other: RectF) -> RectF {
+        RectF::from_points(
+            self.origin.min(other.origin),
+            self.lower_right.max(other.lower_right),
+        )
+    }
+}
+
+impl Add<Vector2F> for RectF {
+    type Output = RectF;
+    #[inline]
+    fn add(self, v: Vector2F) -> RectF {
+        RectF::from_points(self.origin + v, self.lower_right + v)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// RectI
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Default, Copy, Clone, PartialEq, Eq)]
+pub struct RectI {
+    origin: Vector2I,
+    lower_right: Vector2I,
+}
+
+impl RectI {
+    /// Construct a rectangle from two corner points (no normalisation; see
+    /// [`RectF::from_points`] for rationale).
+    #[inline]
+    pub fn from_points(origin: Vector2I, lower_right: Vector2I) -> Self {
+        RectI {
+            origin,
+            lower_right,
+        }
+    }
+
+    #[inline]
+    pub fn min_x(self) -> i32 {
+        self.origin.x
+    }
+
+    #[inline]
+    pub fn min_y(self) -> i32 {
+        self.origin.y
+    }
+
+    #[inline]
+    pub fn max_x(self) -> i32 {
+        self.lower_right.x
+    }
+
+    #[inline]
+    pub fn max_y(self) -> i32 {
+        self.lower_right.y
+    }
+}
+
+// ---------------------------------------------------------------------------
+// LineSegment2F
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Default, Copy, Clone, PartialEq)]
+pub struct LineSegment2F {
+    from: Vector2F,
+    to: Vector2F,
+}
+
+impl LineSegment2F {
+    #[inline]
+    pub fn new(from: Vector2F, to: Vector2F) -> Self {
+        LineSegment2F { from, to }
+    }
+
+    #[inline]
+    pub fn from(self) -> Vector2F {
+        self.from
+    }
+
+    #[inline]
+    pub fn to(self) -> Vector2F {
+        self.to
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Matrix2x2F
+// ---------------------------------------------------------------------------
+
+/// Row-major 2×2 matrix.
+///
+/// `row_major(a, b, c, d)` represents:
+///
+/// ```text
+/// [ a  b ]
+/// [ c  d ]
+/// ```
+///
+/// applied to a point `(x, y)` as `(a*x + b*y, c*x + d*y)`.
+#[derive(Debug, Default, Copy, Clone, PartialEq)]
+pub struct Matrix2x2F {
+    pub m11: f32,
+    pub m12: f32,
+    pub m21: f32,
+    pub m22: f32,
+}
+
+impl Matrix2x2F {
+    #[inline]
+    pub const fn row_major(m11: f32, m12: f32, m21: f32, m22: f32) -> Self {
+        Matrix2x2F { m11, m12, m21, m22 }
+    }
+
+    /// Build a uniform or non-uniform scale matrix from a scalar or vector.
+    #[inline]
+    pub fn from_scale<S: Into<Vector2F>>(scale: S) -> Self {
+        let s = scale.into();
+        Matrix2x2F::row_major(s.x(), 0.0, 0.0, s.y())
+    }
+}
+
+impl From<f32> for Vector2F {
+    #[inline]
+    fn from(s: f32) -> Self {
+        Vector2F::splat(s)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Transform2F
+// ---------------------------------------------------------------------------
+
+/// 2D affine transform.
+///
+/// Equivalent to `matrix` followed by translation `vector`:
+/// `(x, y) ↦ (m11*x + m12*y + vector.x, m21*x + m22*y + vector.y)`.
+#[derive(Debug, Default, Copy, Clone, PartialEq)]
+pub struct Transform2F {
+    pub matrix: Matrix2x2F,
+    pub vector: Vector2F,
+}
+
+impl Transform2F {
+    /// Construct from the six row-major components of the augmented matrix.
+    #[inline]
+    pub const fn row_major(
+        m11: f32,
+        m12: f32,
+        m21: f32,
+        m22: f32,
+        m31: f32,
+        m32: f32,
+    ) -> Self {
+        Transform2F {
+            matrix: Matrix2x2F::row_major(m11, m12, m21, m22),
+            vector: Vector2F::new(m31, m32),
+        }
+    }
+}
+
+impl Mul<Vector2F> for Transform2F {
+    type Output = Vector2F;
+    #[inline]
+    fn mul(self, v: Vector2F) -> Vector2F {
+        Vector2F::new(
+            self.matrix.m11 * v.x + self.matrix.m12 * v.y + self.vector.x,
+            self.matrix.m21 * v.x + self.matrix.m22 * v.y + self.vector.y,
+        )
+    }
+}
+
+impl Mul<RectF> for Transform2F {
+    type Output = RectF;
+    #[inline]
+    fn mul(self, r: RectF) -> RectF {
+        // Transform each of the four corners and rebuild the AABB.
+        let p0 = self * Vector2F::new(r.min_x(), r.min_y());
+        let p1 = self * Vector2F::new(r.max_x(), r.min_y());
+        let p2 = self * Vector2F::new(r.min_x(), r.max_y());
+        let p3 = self * Vector2F::new(r.max_x(), r.max_y());
+        let mn = p0.min(p1).min(p2).min(p3);
+        let mx = p0.max(p1).max(p2).max(p3);
+        RectF::from_points(mn, mx)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn vector_arithmetic() {
+        let a = Vector2F::new(1.0, 2.0);
+        let b = Vector2F::new(3.0, 4.0);
+        assert_eq!(a + b, Vector2F::new(4.0, 6.0));
+        assert_eq!(b - a, Vector2F::new(2.0, 2.0));
+        assert_eq!(a * b, Vector2F::new(3.0, 8.0));
+        assert_eq!(b / a, Vector2F::new(3.0, 2.0));
+        assert_eq!(a * 2.0, Vector2F::new(2.0, 4.0));
+        assert_eq!(a.min(b), a);
+        assert_eq!(a.max(b), b);
+        assert_eq!(
+            Vector2F::new(5.0, -1.0).clamp(a, b),
+            Vector2F::new(3.0, 2.0)
+        );
+    }
+
+    #[test]
+    fn rect_round_out_and_union() {
+        let r = RectF::from_points(vec2f(0.5, 1.2), vec2f(2.7, 3.1));
+        let r2 = r.round_out();
+        assert_eq!(r2.min_x(), 0.0);
+        assert_eq!(r2.min_y(), 1.0);
+        assert_eq!(r2.max_x(), 3.0);
+        assert_eq!(r2.max_y(), 4.0);
+
+        let u = r.union_point(vec2f(-1.0, 5.0));
+        assert_eq!(u.min_x(), -1.0);
+        assert_eq!(u.max_y(), 5.0);
+
+        let other = RectF::from_points(vec2f(2.0, 0.0), vec2f(4.0, 1.5));
+        let u2 = r.union_rect(other);
+        assert_eq!(u2.min_x(), 0.5);
+        assert_eq!(u2.min_y(), 0.0);
+        assert_eq!(u2.max_x(), 4.0);
+        assert_eq!(u2.max_y(), 3.1);
+    }
+
+    #[test]
+    fn rect_contains_point_and_translate() {
+        let r = RectF::from_points(vec2f(0.0, 0.0), vec2f(10.0, 10.0));
+        assert!(r.contains_point(vec2f(5.0, 5.0)));
+        assert!(!r.contains_point(vec2f(10.0, 5.0))); // exclusive on far edge
+        assert!(r.contains_point(vec2f(0.0, 0.0))); // inclusive on origin
+
+        let t = r + vec2f(2.0, 3.0);
+        assert_eq!(t.min_x(), 2.0);
+        assert_eq!(t.max_y(), 13.0);
+    }
+
+    #[test]
+    fn transform_applies_matrix_then_translation() {
+        // Pure translation
+        let t = Transform2F::row_major(1.0, 0.0, 0.0, 1.0, 5.0, 7.0);
+        assert_eq!(t * vec2f(2.0, 3.0), vec2f(7.0, 10.0));
+
+        // Pure scale
+        let s = Transform2F {
+            matrix: Matrix2x2F::from_scale(vec2f(2.0, 3.0)),
+            vector: Vector2F::zero(),
+        };
+        assert_eq!(s * vec2f(4.0, 5.0), vec2f(8.0, 15.0));
+
+        // Scale then translate
+        let st = Transform2F {
+            matrix: Matrix2x2F::from_scale(vec2f(2.0, 3.0)),
+            vector: vec2f(1.0, 1.0),
+        };
+        assert_eq!(st * vec2f(4.0, 5.0), vec2f(9.0, 16.0));
+
+        // row-major 90° rotation: (x, y) -> (-y, x)
+        let r = Transform2F::row_major(0.0, -1.0, 1.0, 0.0, 0.0, 0.0);
+        assert_eq!(r * vec2f(1.0, 0.0), vec2f(0.0, 1.0));
+    }
+
+    #[test]
+    fn transform_of_rect_is_aabb_of_corners() {
+        // 90° rotation around origin.
+        let rot = Transform2F::row_major(0.0, -1.0, 1.0, 0.0, 0.0, 0.0);
+        let r = RectF::from_points(vec2f(1.0, 2.0), vec2f(3.0, 4.0));
+        let out = rot * r;
+        // Corners (1,2) (3,2) (1,4) (3,4) -> (-2,1) (-2,3) (-4,1) (-4,3)
+        assert_eq!(out.min_x(), -4.0);
+        assert_eq!(out.min_y(), 1.0);
+        assert_eq!(out.max_x(), -2.0);
+        assert_eq!(out.max_y(), 3.0);
+    }
+
+    #[test]
+    fn matrix_from_scalar_or_vector_scale() {
+        let a = Matrix2x2F::from_scale(2.0);
+        assert_eq!(a, Matrix2x2F::row_major(2.0, 0.0, 0.0, 2.0));
+        let b = Matrix2x2F::from_scale(vec2f(2.0, 3.0));
+        assert_eq!(b, Matrix2x2F::row_major(2.0, 0.0, 0.0, 3.0));
+    }
+}

--- a/src/gpos.rs
+++ b/src/gpos.rs
@@ -6,7 +6,6 @@
 //!
 //! — <https://docs.microsoft.com/en-us/typography/opentype/spec/gpos>
 
-use itertools::Itertools;
 use tinyvec::tiny_vec;
 use unicode_general_category::GeneralCategory;
 
@@ -183,7 +182,14 @@ pub fn apply_features(
         kern::apply(&kern, script_tag, infos)?;
     }
 
-    for lookup_index in lookup_indices.iter().copied().dedup() {
+    // Equivalent to `Itertools::dedup` — skip runs of equal consecutive
+    // values. The slice is sorted just above, so this collapses duplicates.
+    let mut last: Option<u16> = None;
+    for lookup_index in lookup_indices.iter().copied().filter(|&i| {
+        let new = last != Some(i);
+        last = Some(i);
+        new
+    }) {
         gpos_apply_lookup(
             gpos_cache,
             gpos_table,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -128,6 +128,7 @@ pub mod binary;
 pub mod bitmap;
 pub mod cff;
 pub mod checksum;
+mod crc32;
 pub mod context;
 pub mod error;
 pub mod font;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,12 +80,11 @@
 //!
 //! ### Cargo Features
 //!
-//! | Feature       | Description                              | Default Enabled | Extra Dependencies    |
-//! |---------------|------------------------------------------|:---------------:|-----------------------|
-//! | `outline`     | Enable code for accessing glyph outlines |        ✅       | `pathfinder_geometry` |
-//! | `flate2_zlib` | Use the zlib backend to flate2           |        ✅       | `zlib`                |
-//! | `flate2_rust` | Use the Rust backend to flate2           |        ❌       | `miniz_oxide`         |
-//! | `prince`      | Enable Prince specific tests and code    |        ❌       |                       |
+//! | Feature       | Description                              | Default Enabled | Extra Dependencies |
+//! |---------------|------------------------------------------|:---------------:|--------------------|
+//! | `flate2_zlib` | Use the zlib backend to flate2           |        ✅       | `zlib`             |
+//! | `flate2_rust` | Use the Rust backend to flate2           |        ❌       | `miniz_oxide`      |
+//! | `prince`      | Enable Prince specific tests and code    |        ❌       |                    |
 //!
 //! **Note:** In our testing the `zlib` `flate2` backend was faster but you may
 //! prefer the Rust backend for a pure Rust solution when compiling to WASM or
@@ -159,7 +158,6 @@ pub mod woff;
 pub mod woff2;
 
 pub use font::Font;
-pub use pathfinder_geometry;
 pub use tinyvec;
 
 pub const DOTTED_CIRCLE: char = '◌';

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -130,6 +130,7 @@ pub mod cff;
 pub mod checksum;
 mod crc32;
 pub mod context;
+pub mod geom;
 pub mod error;
 pub mod font;
 pub mod font_data;

--- a/src/outline.rs
+++ b/src/outline.rs
@@ -22,8 +22,7 @@
 //! use allsorts::font_data::FontData;
 //! use allsorts::gsub::RawGlyph;
 //! use allsorts::outline::{OutlineBuilder, OutlineSink};
-//! use allsorts::pathfinder_geometry::line_segment::LineSegment2F;
-//! use allsorts::pathfinder_geometry::vector::Vector2F;
+//! use allsorts::geom::{LineSegment2F, Vector2F};
 //! use allsorts::tables::glyf::{GlyfVisitorContext, LocaGlyf};
 //! use allsorts::tables::loca::{owned, LocaTable};
 //! use allsorts::tables::{FontTableProvider, SfntVersion};
@@ -160,9 +159,9 @@
 
 use std::cmp::Ordering;
 
-use pathfinder_geometry::vector::Vector2F;
-use pathfinder_geometry::{line_segment::LineSegment2F, rect::RectF};
 use tinyvec::{array_vec, ArrayVec};
+
+use crate::geom::{LineSegment2F, RectF, Vector2F};
 
 use crate::tables::glyf::{BoundingBox, Point as GlyfPoint};
 use crate::tables::variable_fonts::OwnedTuple;
@@ -463,7 +462,7 @@ impl From<GlyfPoint> for Vector2F {
 
 #[cfg(test)]
 mod tests {
-    use pathfinder_geometry::vector::vec2f;
+    use crate::geom::vec2f;
 
     use crate::assert_close;
 

--- a/src/tables/cmap.rs
+++ b/src/tables/cmap.rs
@@ -10,7 +10,6 @@ pub(crate) mod subset;
 
 use std::collections::HashMap;
 
-use itertools::izip;
 
 use crate::binary::read::{ReadArray, ReadArrayIter, ReadBinary, ReadCtxt, ReadFrom, ReadScope};
 use crate::binary::write::{WriteBinary, WriteContext};
@@ -817,12 +816,12 @@ trait Format4 {
     {
         // Format 4 sub-tables can only map a 16-bit character range
         let ch = u16::try_from(ch)?;
-        let zipped = izip!(
-            self.start_codes(),
-            self.end_codes(),
-            self.id_deltas(),
-            self.id_range_offsets()
-        );
+        let zipped = self
+            .start_codes()
+            .zip(self.end_codes())
+            .zip(self.id_deltas())
+            .zip(self.id_range_offsets())
+            .map(|(((start, end), delta), offset)| (start, end, delta, offset));
         for (i, (start_code, end_code, id_delta, id_range_offset)) in zipped.enumerate() {
             // Find segment that contains `ch`
             if start_code <= ch && ch <= end_code {
@@ -844,12 +843,12 @@ trait Format4 {
     where
         Self: Sized + Copy,
     {
-        let zipped = izip!(
-            self.start_codes(),
-            self.end_codes(),
-            self.id_deltas(),
-            self.id_range_offsets()
-        );
+        let zipped = self
+            .start_codes()
+            .zip(self.end_codes())
+            .zip(self.id_deltas())
+            .zip(self.id_range_offsets())
+            .map(|(((start, end), delta), offset)| (start, end, delta, offset));
         for (i, (start_code, end_code, id_delta, id_range_offset)) in zipped.enumerate() {
             for (offset_from_start, ch) in (start_code..=end_code).enumerate() {
                 let glyph_id = self.glyph_id_for_id_range_offset(

--- a/src/tables/colr.rs
+++ b/src/tables/colr.rs
@@ -9,11 +9,9 @@ use std::fmt;
 use std::fmt::Write;
 use std::str::FromStr;
 
-use pathfinder_geometry::line_segment::LineSegment2F;
-use pathfinder_geometry::rect::RectF;
-use pathfinder_geometry::transform2d::Transform2F;
-use pathfinder_geometry::vector::{vec2f, Vector2F};
 use rustc_hash::FxHashSet;
+
+use crate::geom::{vec2f, LineSegment2F, RectF, Transform2F, Vector2F};
 
 use super::{F2Dot14, Fixed};
 use crate::binary::{U24Be, U32Be};

--- a/src/tables/glyf.rs
+++ b/src/tables/glyf.rs
@@ -14,7 +14,6 @@ mod variation;
 use std::mem;
 use std::sync::Arc;
 
-use itertools::Itertools;
 use log::warn;
 use pathfinder_geometry::transform2d::Matrix2x2F;
 use pathfinder_geometry::vector::Vector2F;
@@ -304,10 +303,14 @@ impl ReadBinaryDep for GlyfTable<'_> {
             return Err(ParseError::BadIndex);
         }
 
-        let glyph_records = loca
-            .offsets
-            .iter()
-            .tuple_windows()
+        let glyph_records = (0..loca.offsets.len() - 1)
+            .map(|i| {
+                // NOTE(unwrap): Bounded by `loca.offsets.len() - 1`, both
+                // indices are guaranteed in range.
+                let start = loca.offsets.get(i).unwrap();
+                let end = loca.offsets.get(i + 1).unwrap();
+                (start, end)
+            })
             .map(|(start, end)| match end.checked_sub(start) {
                 Some(0) => Ok(GlyfRecord::empty()),
                 Some(length) => {

--- a/src/tables/glyf.rs
+++ b/src/tables/glyf.rs
@@ -15,8 +15,6 @@ use std::mem;
 use std::sync::Arc;
 
 use log::warn;
-use pathfinder_geometry::transform2d::Matrix2x2F;
-use pathfinder_geometry::vector::Vector2F;
 use rustc_hash::FxHashMap;
 
 use crate::binary::read::{
@@ -25,6 +23,7 @@ use crate::binary::read::{
 use crate::binary::write::{WriteBinary, WriteBinaryDep, WriteContext};
 use crate::binary::{word_align, I16Be, U16Be, I8, U8};
 use crate::error::{ParseError, WriteError};
+use crate::geom::{Matrix2x2F, Vector2F};
 use crate::tables::loca::{owned, LocaTable};
 use crate::tables::os2::Os2;
 use crate::tables::{

--- a/src/tables/glyf/outline.rs
+++ b/src/tables/glyf/outline.rs
@@ -1,9 +1,7 @@
 use std::borrow::Cow;
 
-use pathfinder_geometry::transform2d::{Matrix2x2F, Transform2F};
-use pathfinder_geometry::vector::Vector2F;
-
 use crate::binary::read::ReadScope;
+use crate::geom::{Matrix2x2F, Transform2F, Vector2F};
 use crate::error::ParseError;
 use crate::outline::{OutlineBuilder, OutlineSink};
 use crate::tables::os2::Os2;
@@ -40,8 +38,7 @@ use contour::{Contour, CurvePoint};
 /// use allsorts::tables::FontTableProvider;
 /// use allsorts::tables::OpenTypeFont;
 /// use allsorts::tag;
-/// use pathfinder_geometry::line_segment::LineSegment2F;
-/// use pathfinder_geometry::vector::Vector2F;
+/// use allsorts::geom::{LineSegment2F, Vector2F};
 ///
 /// struct DebugVisitor {
 ///     outlines: String,
@@ -449,8 +446,8 @@ fn visit_simple_glyph_outline<S: OutlineSink>(
 }
 
 mod contour {
+    use crate::geom::Vector2F;
     use crate::tables::glyf::{Point, SimpleGlyphFlagExt, SimpleGlyphFlags};
-    use pathfinder_geometry::vector::Vector2F;
 
     pub struct Contour<'points> {
         points_and_flags: &'points [(SimpleGlyphFlags, Point)],
@@ -573,10 +570,8 @@ mod contour {
 
 #[cfg(test)]
 mod tests {
-    use pathfinder_geometry::line_segment::LineSegment2F;
-    use pathfinder_geometry::vector::vec2f;
-
     use crate::binary::read::ReadScope;
+    use crate::geom::{vec2f, LineSegment2F};
     use crate::binary::write::{WriteBinaryDep, WriteBuffer};
     use crate::tables::glyf::tests::{composite_glyph_fixture, simple_glyph_fixture};
     use crate::tables::glyf::{GlyfRecord, GlyfTable, Point, SimpleGlyphFlag, SimpleGlyphFlags};

--- a/src/tables/glyf/variation.rs
+++ b/src/tables/glyf/variation.rs
@@ -1,11 +1,8 @@
 use std::collections::BTreeMap;
 use std::ops::RangeInclusive;
 
-use pathfinder_geometry::rect::RectF;
-use pathfinder_geometry::transform2d::{Matrix2x2F, Transform2F};
-use pathfinder_geometry::vector::{vec2f, Vector2F};
-
 use crate::error::ParseError;
+use crate::geom::{vec2f, Matrix2x2F, RectF, Transform2F, Vector2F};
 use crate::tables::glyf::{
     calculate_phantom_points, BoundingBox, ComponentOffsets, CompositeGlyph,
     CompositeGlyphArgument, CompositeGlyphComponent, CompositeGlyphFlag, CompositeGlyphFlagExt,
@@ -531,8 +528,8 @@ mod tests {
     use crate::tables::variable_fonts::fvar::FvarTable;
     use crate::tables::{FontTableProvider, HeadTable, MaxpTable, NameTable};
     use crate::tests::read_fixture;
+    use crate::geom::vec2i;
     use crate::{assert_close, tag};
-    use pathfinder_geometry::vector::vec2i;
 
     #[test]
     fn apply_variations() -> Result<(), ReadWriteError> {

--- a/src/variations.rs
+++ b/src/variations.rs
@@ -7,9 +7,9 @@ use std::fmt;
 use std::fmt::Write;
 use std::str::FromStr;
 
-use pathfinder_geometry::rect::RectI;
-use pathfinder_geometry::vector::vec2i;
 use rustc_hash::FxHashSet;
+
+use crate::geom::{vec2i, RectI};
 
 use crate::binary::read::{ReadArrayCow, ReadScope};
 use crate::cff::cff2::CFF2;

--- a/src/variations.rs
+++ b/src/variations.rs
@@ -515,7 +515,7 @@ fn generate_postscript_name(
 
     if postscript_name.len() > 63 {
         // Too long, construct "last resort" name
-        let crc = crc32fast::hash(postscript_name.as_bytes());
+        let crc = crate::crc32::hash(postscript_name.as_bytes());
         let hash = format!("-{:X}...", crc);
         // Ensure prefix is short enough when prepended to hash. Truncate is safe as
         // prefix is ASCII only.

--- a/src/woff2.rs
+++ b/src/woff2.rs
@@ -9,9 +9,29 @@ use std::borrow::Cow;
 use std::collections::HashMap;
 use std::io::{Cursor, Read};
 
-use itertools::Either;
-
 use self::lut::{XYTriplet, COORD_LUT, KNOWN_TABLE_TAGS};
+
+/// Sum type that lets a function return one of two iterator shapes
+/// behind a single `impl Iterator` without pulling in `itertools::Either`.
+enum Either<L, R> {
+    Left(L),
+    Right(R),
+}
+
+impl<L, R, T> Iterator for Either<L, R>
+where
+    L: Iterator<Item = T>,
+    R: Iterator<Item = T>,
+{
+    type Item = T;
+
+    fn next(&mut self) -> Option<T> {
+        match self {
+            Either::Left(l) => l.next(),
+            Either::Right(r) => r.next(),
+        }
+    }
+}
 use crate::binary::read::{
     ReadArray, ReadArrayCow, ReadBinary, ReadBinaryDep, ReadBuf, ReadCtxt, ReadFrom, ReadScope,
 };
@@ -911,11 +931,12 @@ impl Woff2TableProvider {
         index: usize,
     ) -> impl Iterator<Item = &'a TableDirectoryEntry> {
         if let Some(collection_directory) = &woff.collection_directory {
+            // NOTE(unwrap): index is determined valid in woff2_read_tables.
             Either::Left(
                 collection_directory
                     .get(index)
                     .map(|font| font.table_entries(woff))
-                    .unwrap(), // NOTE(unwrap): It's assumed that index is determined valid in woff2_read_tables
+                    .unwrap(),
             )
         } else {
             Either::Right(woff.table_directory.iter())

--- a/tests/aots.rs
+++ b/tests/aots.rs
@@ -2,7 +2,6 @@ mod common;
 
 use std::path::Path;
 
-use itertools::Itertools;
 use tinyvec::tiny_vec;
 
 use allsorts::binary::read::ReadScope;

--- a/tests/aots.rs
+++ b/tests/aots.rs
@@ -44,7 +44,7 @@ fn cmap_test(font: &str, platform: u16, encoding: u16, inputs: &[u32], expected:
     let actual = inputs
         .iter()
         .map(|char_code| cmap_subtable.map_glyph(*char_code).unwrap().unwrap_or(0))
-        .collect_vec();
+        .collect::<Vec<_>>();
     assert_eq!(actual, expected);
 }
 
@@ -124,7 +124,7 @@ fn gsub_test(
         &mut glyphs,
     )
     .unwrap();
-    let glyph_indices = glyphs.into_iter().map(|g| g.glyph_index).collect_vec();
+    let glyph_indices = glyphs.into_iter().map(|g| g.glyph_index).collect::<Vec<_>>();
 
     assert_eq!(glyph_indices, expected);
 }

--- a/tests/cff.rs
+++ b/tests/cff.rs
@@ -152,12 +152,12 @@ fn test_read_write_cff_cid() {
             .local_subr_indices
             .iter()
             .map(|maybe_index| maybe_index.as_ref().map(|index| index.len()))
-            .collect_vec(),
+            .collect::<Vec<_>>(),
         expected_data
             .local_subr_indices
             .iter()
             .map(|maybe_index| maybe_index.as_ref().map(|index| index.len()))
-            .collect_vec(),
+            .collect::<Vec<_>>(),
     );
     assert_eq!(actual_data.fd_select, expected_data.fd_select);
 }

--- a/tests/cff.rs
+++ b/tests/cff.rs
@@ -8,7 +8,6 @@ use std::fmt::Debug;
 use std::fmt::Write;
 
 use allsorts::subset::CmapTarget;
-use itertools::Itertools;
 
 use crate::common::read_fixture;
 use allsorts::binary::read::ReadScope;

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -1,9 +1,9 @@
 use std::{
     io::BufRead,
     path::{Path, PathBuf},
+    sync::OnceLock,
 };
 
-use lazy_static::lazy_static;
 use regex::Regex;
 
 pub fn fixture_path<P: AsRef<Path>>(path: P) -> PathBuf {
@@ -43,11 +43,11 @@ fn parse_expected_output(expected_output: &str, ignore: &[u16]) -> (Vec<u16>, Op
             .collect()
     }
 
-    lazy_static! {
-        static ref REGEX: Regex = Regex::new(r"^\[(\d+(?:\|\d+)*)\](?:\s*:\s*(.*))?$").unwrap();
-    }
+    static REGEX: OnceLock<Regex> = OnceLock::new();
+    let regex = REGEX
+        .get_or_init(|| Regex::new(r"^\[(\d+(?:\|\d+)*)\](?:\s*:\s*(.*))?$").unwrap());
 
-    if let Some(captures) = REGEX.captures(expected_output) {
+    if let Some(captures) = regex.captures(expected_output) {
         let indices = parse(&captures[1], ignore);
         let reason = captures.get(2).map(|s| String::from(s.as_str()));
 


### PR DESCRIPTION
This PR removes 8 direct dependencies and replaces them with stdlib equivalents or small in-tree implementations. The goal here is to reduce the attack surface for supply-chain attacks by removing unnecessary dependencies if we only use 1 - 2 functions. With default features the transitive crate count drops from 54 → 42; with `--no-default-features` it drops from 47 → 34.

**It is best to review this commit-by-commit, not the entire PR at once - many changes are only mechanical.** 

## Dependencies removed

- `libc`: unused dependency — deleted
- `bitreader`: inline bit reader in `src/binary/read.rs`
- `byteorder`: replace 3 usages with stdlib `from_be_bytes` / `from_le_bytes`
- `crc32fast`: only one usage in `generate_postscript_name` for an edge case: still pulled in via flate2, but can be removed with flate2 feature flag adjustments
- `lazy_static`: 3 usages, replaced by `std::sync::OnceLock` (stable since rustc 1.70)
- `itertools`: stdlib `Iterator::zip`, `.collect::<Vec<_>>()`, windowed iterators, `dedup()` via `filter()`
- `num-traits`: only 2 call-sites, inlined wrt. usage

The largest removal / inlining is:

- `pathfinder_geometry`: only a few structs with basic geometry ops used, inlined in `src/geom.rs`

This was also the largest saving in transitive dependencies, but allsorts only uses some definitions and very basic geometry math, so very easy to review.

Overall, I'm obviously not trying to overwhelm people with automated AI PRs, I'm just looking if there's anything we can shed easily and inline to not depend on tons of dependencies. Some deps like `ouroboros` and `enumflags2` still pull in lots of transitive deps.

## cargo tree — before (master)

```
  allsorts v0.16.1
  ├── bitreader v0.3.11
  │   └── cfg-if v1.0.4
  ├── brotli-decompressor v5.0.0
  │   ├── alloc-no-stdlib v2.0.4
  │   └── alloc-stdlib v0.2.2
  │       └── alloc-no-stdlib v2.0.4                                                                                                                                                                          
  ├── byteorder v1.5.0                                                                                                                                                                                          
  ├── crc32fast v1.5.0                                                                                                                                                                                          
  │   └── cfg-if v1.0.4                                                                                                                                                                                         
  ├── encoding_rs v0.8.35                                                                                                                                                                                       
  │   └── cfg-if v1.0.4                                                                                                                                                                                         
  ├── enumflags2 v0.7.12                                                                                                                                                                                        
  │   └── enumflags2_derive v0.7.12 (proc-macro)
  ├── flate2 v1.1.9                                  (optional)                                                                                                                                                  
  │   ├── crc32fast v1.5.0 (*)                                                                                                                                                                                  
  │   └── libz-sys v1.1.28                                                                                                                                                                                      
  ├── glyph-names v0.2.0                                                                                                                                                                                        
  ├── itertools v0.14.0                                                                                                                                                                                         
  │   └── either v1.15.0                                                                                                                                                                                        
  ├── lazy_static v1.5.0                                                                                                                                                                                        
  ├── libc v0.2.186                                                                                                                                                                                             
  ├── log v0.4.29                                                                                                                                                                                               
  ├── num-traits v0.2.19                                                                                                                                                                                        
  │   [build-dependencies]                                                                                                                                                                                      
  │   └── autocfg v1.5.0          
  ├── ouroboros v0.18.5                                                                                                                                                                                         
  ├── pathfinder_geometry v0.5.1                                                                                                                                                                                
  │   ├── log v0.4.29                                                                                                                                                                                         
  │   └── pathfinder_simd v0.5.6                                                                                                                                                                                
  │       [build-dependencies]                                                                                                                                                                                
  │       └── rustc_version v0.4.1                                                                                                                                                                              
  │           └── semver v1.0.28                                  
  ├── rustc-hash v2.1.2                                                                                                                                                                                         
  ├── tinyvec v1.11.0                                                                                                                                                                                           
  ├── ucd-trie v0.1.7                                                                                                                                                                                         
  ├── unicode-canonical-combining-class v1.0.0                                                                                                                                                                  
  ├── unicode-general-category v1.1.0                                                                                                                                                                           
  └── unicode-joining-type v1.0.0                                                                                                                                                                               
```
                                                                                                                                                                                         
## cargo tree — after (reduce-deps)                                                                                                                                                                              

```                                                                                                                                                                                              
  allsorts v0.16.1                                                                                                                                                                                              
  ├── brotli-decompressor v5.0.0                                  
  │   ├── alloc-no-stdlib v2.0.4                                                                                                                                                                                
  │   └── alloc-stdlib v0.2.2                                     
  │       └── alloc-no-stdlib v2.0.4                                                                                                                                                                          
  ├── encoding_rs v0.8.35                                                                                                                                                                                       
  │   └── cfg-if v1.0.4           
  ├── enumflags2 v0.7.12                                                                                                                                                                                        
  │   └── enumflags2_derive v0.7.12 (proc-macro)                                                                                                                                                                
  ├── flate2 v1.1.9                                   (optional)  
  │   ├── crc32fast v1.5.0                                                                                                                                                                                      
  │   └── libz-sys v1.1.28                                                                                                                                                                                      
  ├── glyph-names v0.2.0          
  ├── log v0.4.29                                                                                                                                                                                               
  ├── ouroboros v0.18.5                                                                                                                                                                                         
  ├── rustc-hash v2.1.2           
  ├── tinyvec v1.11.0                                                                                                                                                                                           
  ├── ucd-trie v0.1.7                                                                                                                                                                                         
  ├── unicode-canonical-combining-class v1.0.0                                                                                                                                                                  
  ├── unicode-general-category v1.1.0
  └── unicode-joining-type v1.0.0                                                                                                                                                                               
```
                                                                                                                                                                                                        
Each commit on the branch is a single, self-contained removal; tests pass at every step.                                                                                                                      
